### PR TITLE
fix(player): 全屏切换

### DIFF
--- a/simple_live_app/lib/modules/live_room/player/player_controller.dart
+++ b/simple_live_app/lib/modules/live_room/player/player_controller.dart
@@ -254,7 +254,7 @@ mixin PlayerSystemMixin on PlayerMixin, PlayerStateMixin, PlayerDanmakuMixin {
   }
 
   /// 进入全屏
-  void enterFullScreen() {
+  void enterFullScreen() async {
     fullScreenState.value = true;
     if (Platform.isAndroid || Platform.isIOS) {
       //全屏
@@ -264,18 +264,28 @@ mixin PlayerSystemMixin on PlayerMixin, PlayerStateMixin, PlayerDanmakuMixin {
         setLandscapeOrientation();
       }
     } else {
-      windowManager.setFullScreen(true);
+      bool isMaximized = await windowManager.isMaximized();
+      if (isMaximized) {
+        await windowManager.setFullScreen(true);
+        await windowManager.setTitleBarStyle(TitleBarStyle.hidden);
+      }
+      await windowManager.setFullScreen(true);
     }
     //danmakuController?.clear();
   }
 
   /// 退出全屏
-  void exitFull() {
+  void exitFull() async {
     if (Platform.isAndroid || Platform.isIOS) {
       SystemChrome.setEnabledSystemUIMode(SystemUiMode.edgeToEdge,
           overlays: SystemUiOverlay.values);
       setPortraitOrientation();
     } else {
+      bool isMaximized = await windowManager.isMaximized();
+      if (isMaximized) {
+        await windowManager.setFullScreen(false);
+        await windowManager.setTitleBarStyle(TitleBarStyle.normal);
+      }
       windowManager.setFullScreen(false);
     }
     fullScreenState.value = false;


### PR DESCRIPTION
Fix https://github.com/SlotSun/dart_simple_live/issues/11

## Sourcery 总结

改进桌面端全屏切换功能，通过等待窗口管理器调用并调整最大化窗口的标题栏样式

Bug 修复:
- 确保在桌面端最大化窗口上，全屏进入/退出时能正确切换标题栏样式

功能增强:
- 将 `enterFullScreen` 和 `exitFull` 方法转换为异步，以等待窗口管理器操作
- 添加窗口最大化检查，以便在切换全屏时根据条件隐藏或显示标题栏样式

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve full-screen toggle on desktop by awaiting window manager calls and adjusting the title bar style for maximized windows

Bug Fixes:
- Ensure full-screen enter/exit properly toggles title bar style on maximized windows in desktop platforms

Enhancements:
- Convert enterFullScreen and exitFull methods to async to await windowManager operations
- Add checks for window maximization to conditionally hide or show the title bar style when toggling full-screen

</details>