### PR TITLE
Feat:flutter qjs

### DIFF
--- a/simple_live_app/linux/flutter/generated_plugin_registrant.cc
+++ b/simple_live_app/linux/flutter/generated_plugin_registrant.cc
@@ -7,7 +7,7 @@
 #include "generated_plugin_registrant.h"
 
 #include <dynamic_color/dynamic_color_plugin.h>
-#include <flutter_js/flutter_js_plugin.h>
+#include <flutter_qjs/flutter_qjs_plugin.h>
 #include <media_kit_libs_linux/media_kit_libs_linux_plugin.h>
 #include <media_kit_video/media_kit_video_plugin.h>
 #include <screen_retriever_linux/screen_retriever_linux_plugin.h>
@@ -19,9 +19,9 @@ void fl_register_plugins(FlPluginRegistry* registry) {
   g_autoptr(FlPluginRegistrar) dynamic_color_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "DynamicColorPlugin");
   dynamic_color_plugin_register_with_registrar(dynamic_color_registrar);
-  g_autoptr(FlPluginRegistrar) flutter_js_registrar =
-      fl_plugin_registry_get_registrar_for_plugin(registry, "FlutterJsPlugin");
-  flutter_js_plugin_register_with_registrar(flutter_js_registrar);
+  g_autoptr(FlPluginRegistrar) flutter_qjs_registrar =
+      fl_plugin_registry_get_registrar_for_plugin(registry, "FlutterQjsPlugin");
+  flutter_qjs_plugin_register_with_registrar(flutter_qjs_registrar);
   g_autoptr(FlPluginRegistrar) media_kit_libs_linux_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "MediaKitLibsLinuxPlugin");
   media_kit_libs_linux_plugin_register_with_registrar(media_kit_libs_linux_registrar);

--- a/simple_live_app/linux/flutter/generated_plugins.cmake
+++ b/simple_live_app/linux/flutter/generated_plugins.cmake
@@ -4,7 +4,7 @@
 
 list(APPEND FLUTTER_PLUGIN_LIST
   dynamic_color
-  flutter_js
+  flutter_qjs
   media_kit_libs_linux
   media_kit_video
   screen_retriever_linux

--- a/simple_live_app/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/simple_live_app/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -10,7 +10,6 @@ import device_info_plus
 import dynamic_color
 import file_picker
 import flutter_inappwebview_macos
-import flutter_js
 import media_kit_libs_macos_video
 import media_kit_video
 import network_info_plus
@@ -30,7 +29,6 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   DynamicColorPlugin.register(with: registry.registrar(forPlugin: "DynamicColorPlugin"))
   FilePickerPlugin.register(with: registry.registrar(forPlugin: "FilePickerPlugin"))
   InAppWebViewFlutterPlugin.register(with: registry.registrar(forPlugin: "InAppWebViewFlutterPlugin"))
-  FlutterJsPlugin.register(with: registry.registrar(forPlugin: "FlutterJsPlugin"))
   MediaKitLibsMacosVideoPlugin.register(with: registry.registrar(forPlugin: "MediaKitLibsMacosVideoPlugin"))
   MediaKitVideoPlugin.register(with: registry.registrar(forPlugin: "MediaKitVideoPlugin"))
   NetworkInfoPlusPlugin.register(with: registry.registrar(forPlugin: "NetworkInfoPlusPlugin"))

--- a/simple_live_app/windows/flutter/generated_plugin_registrant.cc
+++ b/simple_live_app/windows/flutter/generated_plugin_registrant.cc
@@ -9,7 +9,7 @@
 #include <connectivity_plus/connectivity_plus_windows_plugin.h>
 #include <dynamic_color/dynamic_color_plugin_c_api.h>
 #include <flutter_inappwebview_windows/flutter_inappwebview_windows_plugin_c_api.h>
-#include <flutter_js/flutter_js_plugin.h>
+#include <flutter_qjs/flutter_qjs_plugin.h>
 #include <media_kit_libs_windows_video/media_kit_libs_windows_video_plugin_c_api.h>
 #include <media_kit_video/media_kit_video_plugin_c_api.h>
 #include <permission_handler_windows/permission_handler_windows_plugin.h>
@@ -27,8 +27,8 @@ void RegisterPlugins(flutter::PluginRegistry* registry) {
       registry->GetRegistrarForPlugin("DynamicColorPluginCApi"));
   FlutterInappwebviewWindowsPluginCApiRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("FlutterInappwebviewWindowsPluginCApi"));
-  FlutterJsPluginRegisterWithRegistrar(
-      registry->GetRegistrarForPlugin("FlutterJsPlugin"));
+  FlutterQjsPluginRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("FlutterQjsPlugin"));
   MediaKitLibsWindowsVideoPluginCApiRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("MediaKitLibsWindowsVideoPluginCApi"));
   MediaKitVideoPluginCApiRegisterWithRegistrar(

--- a/simple_live_app/windows/flutter/generated_plugins.cmake
+++ b/simple_live_app/windows/flutter/generated_plugins.cmake
@@ -6,7 +6,7 @@ list(APPEND FLUTTER_PLUGIN_LIST
   connectivity_plus
   dynamic_color
   flutter_inappwebview_windows
-  flutter_js
+  flutter_qjs
   media_kit_libs_windows_video
   media_kit_video
   permission_handler_windows

--- a/simple_live_core/lib/src/common/js_engine.dart
+++ b/simple_live_core/lib/src/common/js_engine.dart
@@ -1,30 +1,50 @@
-import 'package:flutter_js/flutter_js.dart';
+import 'package:flutter_qjs/flutter_qjs.dart';
 import 'package:flutter/services.dart';
+import 'package:simple_live_core/simple_live_core.dart';
 
 class JsEngine {
-  static JavascriptRuntime? _jsRuntime;
+  static FlutterQjs? _engine;
 
-  static JavascriptRuntime get jsRuntime => _jsRuntime!;
-
-  static void init() {
-    _jsRuntime ??= getJavascriptRuntime();
-    jsRuntime.enableHandlePromises();
+  static void init({int stackSize = 1024 * 1024}) {
+    if (_engine == null) {
+      _engine = FlutterQjs(stackSize: stackSize);
+      _engine!.dispatch();
+    }
   }
 
-  static Future<JsEvalResult> evaluateAsync(String code) {
-    return jsRuntime.evaluateAsync(code);
+  static FlutterQjs get engine {
+    if (_engine == null) {
+      init();
+    }
+    return _engine!;
   }
 
-  static JsEvalResult evaluate(String code) {
-    return jsRuntime.evaluate(code);
+  static dynamic evaluate(String code) {
+    try {
+      return engine.evaluate(code);
+    } on JSError catch (e) {
+      CoreLog.error("JsEngine evaluate error: $e");
+      return null;
+    }
   }
 
   static Future<void> loadJSFile(String path) async {
-    final jsCode = await rootBundle.loadString(path);
-    jsRuntime.evaluate(jsCode);
+    try {
+      final jsCode = await rootBundle.loadString(path);
+      engine.evaluate(jsCode);
+    } catch (e) {
+      CoreLog.error("JsEngine loadJSFile error: $e");
+    }
   }
 
   static void dispose() {
-    _jsRuntime?.dispose();
+    try {
+      _engine?.port.close();
+      _engine?.close();
+    } catch (e) {
+      CoreLog.error("JsEngine dispose error: $e");
+    } finally {
+      _engine = null;
+    }
   }
 }

--- a/simple_live_core/lib/src/danmaku/douyin_danmaku.dart
+++ b/simple_live_core/lib/src/danmaku/douyin_danmaku.dart
@@ -3,7 +3,6 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:crypto/crypto.dart';
-import 'package:flutter_js/flutter_js.dart';
 import 'package:simple_live_core/simple_live_core.dart';
 import 'package:simple_live_core/src/common/douyin/douyinRequestParams.dart';
 import 'package:simple_live_core/src/common/js_engine.dart';
@@ -225,14 +224,14 @@ class DouyinDanmaku implements LiveDanmaku {
         "identity": "audience",
       };
       JsEngine.init();
-      await JsEngine.loadJSFile('packages/simple_live_core/assets/js/douyin-webmssdk.js');
+      await JsEngine.loadJSFile(
+          'packages/simple_live_core/assets/js/douyin-webmssdk.js');
       String sigParam = params.entries
           .map((entry) => '${entry.key}=${entry.value}')
           .join(',');
       var md5SigParam = md5.convert(utf8.encode(sigParam)).toString();
-      JsEvalResult jsEvalResult =
-          await JsEngine.evaluateAsync("get_sign('$md5SigParam')"); // 异步执行
-      return jsEvalResult.stringResult;
+      var jsEvalResult = JsEngine.evaluate("get_sign('$md5SigParam')");
+      return jsEvalResult.toString();
     } catch (e) {
       CoreLog.error(e);
       return "";

--- a/simple_live_core/lib/src/douyu_site.dart
+++ b/simple_live_core/lib/src/douyu_site.dart
@@ -3,7 +3,6 @@ import 'dart:convert';
 import 'dart:math';
 
 import 'package:crypto/crypto.dart';
-import 'package:flutter_js/flutter_js.dart';
 import 'package:html_unescape/html_unescape.dart';
 import 'package:simple_live_core/simple_live_core.dart';
 import 'package:simple_live_core/src/common/http_client.dart';
@@ -322,30 +321,27 @@ class DouyuSite implements LiveSite {
         "";
     html = html.replaceAll(RegExp(r"eval.*?;}"), "strc;}");
 
-    try{
+    try {
       var did = '10000000000000000000000000001501';
       JsEngine.init();
-      JsEvalResult jsEvalResult =
-          await JsEngine.evaluateAsync("$html;ub98484234();");
-      var res = jsEvalResult.stringResult;
+      var jsEvalResult = JsEngine.evaluate("$html;ub98484234();");
+      var res = jsEvalResult.toString();
       String t10 = (DateTime.now().millisecondsSinceEpoch ~/ 1000).toString();
       RegExp vReg = RegExp(r'v=(\d+)');
       Match? vMatch = vReg.firstMatch(res);
       String? v = vMatch?.group(1);
-      String rb = md5.convert(utf8.encode(rid + did + t10 + (v ?? ""))).toString();
+      String rb =
+          md5.convert(utf8.encode(rid + did + t10 + (v ?? ""))).toString();
       String jsSign = res
           .replaceAll(RegExp(r'return rt;}\);?'), 'return rt;}')
           .replaceAll('(function (', 'function sign(')
           .replaceAll('CryptoJS.MD5(cb).toString()', '"$rb"');
-
-      final params =
-          await JsEngine.evaluateAsync("$jsSign;sign($rid,'$did',$t10);");
-
-      return params.stringResult;
+      var params = JsEngine.evaluate("$jsSign;sign($rid,'$did',$t10);");
+      return params.toString();
     } catch (e) {
       CoreLog.error(e);
       return "";
-    } finally{
+    } finally {
       JsEngine.dispose();
     }
     // 自部署：https://github.com/SlotSun/simple_live_api

--- a/simple_live_core/pubspec.yaml
+++ b/simple_live_core/pubspec.yaml
@@ -19,7 +19,10 @@ dependencies:
   tars_dart:
     path: ./packages/tars_dart
   fixnum: ^1.1.0
-  flutter_js: ^0.8.5
+  flutter_qjs:
+    git:
+      url: https://github.com/wgh136/flutter_qjs.git
+      branch: master
   dart_sm: ^0.1.5
 
 dev_dependencies: 


### PR DESCRIPTION
## Sourcery 总结

通过将 `flutter_js` 替换为 `flutter_qjs`、更新 `JsEngine` API、调整站点实现以及重新配置跨平台的插件注册，将项目迁移至使用 `FlutterQjs` 进行 JavaScript 执行。

增强功能：
- 重构 `JsEngine` 以使用 `FlutterQjs`，支持可配置的堆栈大小、带有错误处理的同步求值方法、简化的 `loadJSFile` 以及健壮的释放逻辑
- 调整 `DouyuSite` 和 `DouyinDanmaku`，使其调用新的 `JsEngine` API，采用同步求值并具有 `null`/错误安全返回
- 更新生成的平台代码，使其在 Linux、Windows 和 macOS 上注册 `FlutterQjsPlugin` 而非 `FlutterJsPlugin`

构建：
- 在 `pubspec.yaml` 中将 `flutter_js` 依赖替换为 `flutter_qjs` (`Git master` 分支)，并相应地更新生成的插件列表

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Migrate the project to use FlutterQjs for JavaScript execution by replacing flutter_js with flutter_qjs, updating JsEngine API, adjusting site implementations, and reconfiguring plugin registration across platforms.

Enhancements:
- Refactor JsEngine to use FlutterQjs with configurable stack size, synchronous evaluate method with error handling, simplified loadJSFile, and robust dispose logic
- Adapt DouyuSite and DouyinDanmaku to invoke the new JsEngine API with synchronous evaluation and null/error-safe returns
- Update generated platform code to register FlutterQjsPlugin instead of FlutterJsPlugin on Linux, Windows, and macOS

Build:
- Replace flutter_js dependency with flutter_qjs (Git master) in pubspec.yaml and update generated plugin lists accordingly

</details>