### PR TITLE
feat:关注清理以及关注刷新优化

### DIFF
--- a/simple_live_app/lib/app/utils/dynamic_filter.dart
+++ b/simple_live_app/lib/app/utils/dynamic_filter.dart
@@ -1,0 +1,184 @@
+import 'package:simple_live_core/simple_live_core.dart';
+
+// 定义筛选条件之间的逻辑关系
+enum LogicalOperator { and, or }
+
+// 定义支持的筛选比较运算符
+enum FilterOperator {
+  equals, // ==
+  notEquals, // !=
+  greaterThan, // >
+  lessThan, // <
+  greaterThanOrEqual, // >=
+  lessThanOrEqual, // <=
+  contains, // 包含（用于List或String）
+}
+
+/// 表示一个单独的筛选条件。
+class Condition {
+  final String field;
+  final FilterOperator operator;
+  final dynamic value;
+
+  /// (可选) 字段转换器
+  ///
+  /// 字段转换器在比较前将数据项中的原始值转换为一个`Comparable`类型。
+  /// 目的对historyModel数据以非标准格式（时长字符串 "HH:MM:SS"）存储。
+  ///
+  /// 该函数接收来自数据项的原始值，通过转换器返回一个`Comparable`对象
+  /// (例如, `Duration`, `int`, `DateTime`)。
+  /// 此`Condition`的`value`字段应为相同`Comparable`类型。
+  final Comparable? Function(dynamic rawValue)? comparableValueProvider;
+
+  Condition(
+    this.field,
+    this.operator,
+    this.value, {
+    this.comparableValueProvider,
+  });
+}
+
+/// 接口:标记可以被转换为Map的对象。
+/// 数据模型类应该实现这个接口
+abstract class Mappable {
+  /// 将对象转换为Map<String, dynamic>。
+  Map<String, dynamic> toMap();
+}
+
+/// (可选) 高级接口用于让模型类自定义实现筛选逻辑。
+///
+/// 模型实现了这个接口，`dynamicFilter` 将会调用其 `evaluate` 方法来判断条件，
+/// 用于实现最高效或最特殊的比较逻辑。
+abstract class Filterable {
+  /// 模型自己判断是否满足某个条件。
+  /// 返回 `true` 表示满足，`false` 表示不满足。
+  bool evaluate(Condition condition);
+}
+
+/// 一个用于动态多条件过滤列表的工具。
+///
+/// 根据一组动态条件过滤一个 `Mappable` 对象列表。
+///
+/// 此函数采用“渐进式增强”的设计：
+/// - 对于简单的模型（只实现 `Mappable`），它会自动通过 `toMap()` 进行筛选。
+/// - 对于复杂的模型（额外实现了 `Filterable`），它会将筛选逻辑的控制权完全交给模型自身的 `evaluate()` 方法。
+///
+/// [T]: 必须是实现了 `Mappable` 接口的类型。
+/// [list]: 要过滤的对象列表。
+/// [conditions]: `Condition` 对象列表，定义了过滤规则。
+/// [logic]: 条件间的逻辑关系 (`and` 或 `or`)。
+/// [takeLast]: (可选) 从结果中获取最后N个元素。
+///
+/// 返回一个 `List<T>`，其中包含通过所有筛选条件的原始对象。
+List<T> dynamicFilter<T extends Mappable>(
+  List<T> list,
+  List<Condition> conditions, {
+  LogicalOperator logic = LogicalOperator.and,
+  int? takeLast = 15,
+}) {
+  // 1. 内容筛选
+  var filteredList = list.where((item) {
+    if (conditions.isEmpty) {
+      return true;
+    }
+
+    bool check(Condition c) {
+      if (item is Filterable) {
+        return (item as Filterable).evaluate(c);
+      } else {
+        // 使用默认逻辑
+        late final Map<String, dynamic> itemMap;
+        try {
+          itemMap = item.toMap();
+        } catch (e, s) {
+          CoreLog.e(
+              "Filter:Failed to convert item to map for default filtering.", s);
+          return false;
+        }
+        return checkConditionOnMap(itemMap, c);
+      }
+    }
+
+    if (logic == LogicalOperator.and) {
+      return conditions.every(check);
+    } else {
+      return conditions.any(check);
+    }
+  }).toList();
+
+  // 2. 位置筛选
+  if (takeLast != null && takeLast > 0) {
+    if (takeLast >= filteredList.length) {
+      return filteredList;
+    }
+    return filteredList.sublist(filteredList.length - takeLast);
+  }
+
+  return filteredList;
+}
+
+/// 默认的、基于Map的条件检查逻辑。
+/// 当一个对象没有实现`Filterable`接口时，`dynamicFilter`会调用此函数。
+bool checkConditionOnMap(Map<String, dynamic> itemMap, Condition condition) {
+  if (!itemMap.containsKey(condition.field)) {
+    return true;
+  }
+
+  final itemValue = itemMap[condition.field];
+  final operand = condition.value;
+
+  // 统一处理需要转换的场景
+  final dynamic transformedItemValue;
+  if (condition.comparableValueProvider != null) {
+    transformedItemValue = condition.comparableValueProvider!(itemValue);
+  } else {
+    transformedItemValue = itemValue;
+  }
+
+  switch (condition.operator) {
+    case FilterOperator.equals:
+      return transformedItemValue == operand;
+    case FilterOperator.notEquals:
+      return transformedItemValue != operand;
+
+    case FilterOperator.greaterThan:
+    case FilterOperator.lessThan:
+    case FilterOperator.greaterThanOrEqual:
+    case FilterOperator.lessThanOrEqual:
+      {
+        if (transformedItemValue == null ||
+            !_isComparable(transformedItemValue, operand)) {
+          return false;
+        }
+        final comparison =
+            (transformedItemValue as Comparable).compareTo(operand);
+
+        if (condition.operator == FilterOperator.greaterThan) {
+          return comparison > 0;
+        }
+        if (condition.operator == FilterOperator.lessThan) {
+          return comparison < 0;
+        }
+        if (condition.operator == FilterOperator.greaterThanOrEqual) {
+          return comparison >= 0;
+        }
+        if (condition.operator == FilterOperator.lessThanOrEqual) {
+          return comparison <= 0;
+        }
+        return false;
+      }
+
+    case FilterOperator.contains:
+      // 'contains' 通常不适用于自定义转换，它在原始值上操作
+      if (itemValue is List) return itemValue.contains(operand);
+      if (itemValue is String && operand is String) {
+        return itemValue.contains(operand);
+      }
+      return false;
+  }
+}
+
+/// 辅助函数，检查两个值是否是可比较的相同类型。
+bool _isComparable(dynamic a, dynamic b) {
+  return a is Comparable && b is Comparable && a.runtimeType == b.runtimeType;
+}

--- a/simple_live_app/lib/models/db/history.dart
+++ b/simple_live_app/lib/models/db/history.dart
@@ -1,9 +1,12 @@
 import 'package:hive/hive.dart';
+import 'package:simple_live_app/app/utils/duration2strUtils.dart';
+import 'package:simple_live_app/app/utils/dynamic_filter.dart';
+
 
 part 'history.g.dart';
 
 @HiveType(typeId: 2)
-class History {
+class History implements Mappable {
   History({
     required this.id,
     required this.roomId,
@@ -36,6 +39,7 @@ class History {
   @HiveField(6)
   String? watchDuration; // "00:00:00"
 
+  Duration get duration => watchDuration!.toDuration();  //for filter
 
   factory History.fromJson(Map<String, dynamic> json) => History(
         id: json["id"],
@@ -44,7 +48,7 @@ class History {
         userName: json["userName"],
         face: json["face"],
         updateTime: DateTime.parse(json["updateTime"]),
-        watchDuration: json["watchDuration"]??"00:00:00",
+        watchDuration: json["watchDuration"] ?? "00:00:00",
       );
 
   Map<String, dynamic> toJson() => {
@@ -54,6 +58,9 @@ class History {
         "userName": userName,
         "face": face,
         "updateTime": updateTime.toString(),
-        "watchDuration": watchDuration??"00:00:00",
+        "watchDuration": watchDuration ?? "00:00:00",
       };
+
+  @override
+  Map<String, dynamic> toMap() => toJson();
 }

--- a/simple_live_app/lib/modules/follow_user/follow_app_setting/follow_app_settings_controller.dart
+++ b/simple_live_app/lib/modules/follow_user/follow_app_setting/follow_app_settings_controller.dart
@@ -6,12 +6,14 @@ import 'package:simple_live_app/app/controller/app_settings_controller.dart';
 import 'package:simple_live_app/app/controller/base_controller.dart';
 import 'package:simple_live_app/app/log.dart';
 import 'package:simple_live_app/app/utils.dart';
+import 'package:simple_live_app/models/db/follow_user.dart';
 import 'package:simple_live_app/models/db/follow_user_tag.dart';
 import 'package:simple_live_app/services/follow_service.dart';
 
 class FollowAppSettingsController extends BaseController {
   final appC = Get.find<AppSettingsController>();
-
+  // 清理池
+  RxList<FollowUser> cleanPoll = <FollowUser>[].obs;
   // 用户自定义标签
   RxList<FollowUserTag> userTagList = <FollowUserTag>[].obs;
 
@@ -201,5 +203,13 @@ class FollowAppSettingsController extends BaseController {
         ),
       ),
     );
+  }
+
+  // todo:关注清理功能
+  void cleanFollow() {
+    if (cleanPoll.isEmpty) {
+      SmartDialog.showToast("没有需要清理的用户");
+      return;
+    }
   }
 }

--- a/simple_live_app/lib/modules/follow_user/follow_app_setting/follow_app_settings_controller.dart
+++ b/simple_live_app/lib/modules/follow_user/follow_app_setting/follow_app_settings_controller.dart
@@ -1,0 +1,7 @@
+﻿import 'package:get/get.dart';
+import 'package:simple_live_app/app/controller/app_settings_controller.dart';
+import 'package:simple_live_app/app/controller/base_controller.dart';
+
+class FollowAppSettingsController extends BaseController{
+  final appC = Get.find<AppSettingsController>();
+}

--- a/simple_live_app/lib/modules/follow_user/follow_app_setting/follow_app_settings_page.dart
+++ b/simple_live_app/lib/modules/follow_user/follow_app_setting/follow_app_settings_page.dart
@@ -61,6 +61,7 @@ class FollowSettingsPage extends GetView<FollowAppSettingsController> {
                     // ),
                     SettingsMenuCheck<FollowUser>(
                       title: '选择要清理的用户',
+                      subtitle: '默认条件为：观看时常低于30分钟，历史观看底部15',
                       confirmText: '清理',
                       itemToString: (user) => user.userName, // 告诉组件如何显示用户名
 

--- a/simple_live_app/lib/modules/follow_user/follow_app_setting/follow_app_settings_page.dart
+++ b/simple_live_app/lib/modules/follow_user/follow_app_setting/follow_app_settings_page.dart
@@ -1,14 +1,14 @@
-import 'package:flutter/material.dart';
+﻿import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import 'package:simple_live_app/app/app_style.dart';
-import 'package:simple_live_app/app/controller/app_settings_controller.dart';
+import 'package:simple_live_app/modules/follow_user/follow_app_setting/follow_app_settings_controller.dart';
 import 'package:simple_live_app/services/follow_service.dart';
 import 'package:simple_live_app/widgets/settings/settings_action.dart';
 import 'package:simple_live_app/widgets/settings/settings_card.dart';
 import 'package:simple_live_app/widgets/settings/settings_number.dart';
 import 'package:simple_live_app/widgets/settings/settings_switch.dart';
 
-class FollowSettingsPage extends GetView<AppSettingsController> {
+class FollowSettingsPage extends GetView<FollowAppSettingsController> {
   const FollowSettingsPage({super.key});
 
   @override
@@ -24,28 +24,28 @@ class FollowSettingsPage extends GetView<AppSettingsController> {
             child: Column(
               children: [
                 Obx(
-                  () => SettingsSwitch(
-                    value: controller.autoUpdateFollowEnable.value,
+                      () => SettingsSwitch(
+                    value: controller.appC.autoUpdateFollowEnable.value,
                     title: "自动更新关注直播状态",
                     onChanged: (e) {
-                      controller.setAutoUpdateFollowEnable(e);
+                      controller.appC.setAutoUpdateFollowEnable(e);
                       FollowService.instance.initTimer();
                     },
                   ),
                 ),
                 Obx(
-                  () => Visibility(
-                    visible: controller.autoUpdateFollowEnable.value,
+                      () => Visibility(
+                    visible: controller.appC.autoUpdateFollowEnable.value,
                     child: AppStyle.divider,
                   ),
                 ),
                 Obx(
-                  () => Visibility(
-                    visible: controller.autoUpdateFollowEnable.value,
+                      () => Visibility(
+                    visible: controller.appC.autoUpdateFollowEnable.value,
                     child: SettingsAction(
                       title: "自动更新间隔",
                       value:
-                          "${controller.autoUpdateFollowDuration.value ~/ 60}小时${controller.autoUpdateFollowDuration.value % 60}分钟",
+                      "${controller.appC.autoUpdateFollowDuration.value ~/ 60}小时${controller.appC.autoUpdateFollowDuration.value % 60}分钟",
                       onTap: () {
                         setTimer(context);
                       },
@@ -54,14 +54,14 @@ class FollowSettingsPage extends GetView<AppSettingsController> {
                 ),
                 AppStyle.divider,
                 Obx(
-                  () => SettingsNumber(
-                    value: controller.updateFollowThreadCount.value,
+                      () => SettingsNumber(
+                    value: controller.appC.updateFollowThreadCount.value,
                     title: "更新线程数",
                     subtitle: "多线程可以能更快的完成加载，但可能会因为请求太频繁导致读取状态失败",
                     min: 1,
                     max: 12,
                     onChanged: (e) {
-                      controller.setUpdateFollowThreadCount(e);
+                      controller.appC.setUpdateFollowThreadCount(e);
                     },
                   ),
                 ),
@@ -77,8 +77,8 @@ class FollowSettingsPage extends GetView<AppSettingsController> {
     var value = await showTimePicker(
       context: context,
       initialTime: TimeOfDay(
-        hour: controller.autoUpdateFollowDuration.value ~/ 60,
-        minute: controller.autoUpdateFollowDuration.value % 60,
+        hour: controller.appC.autoUpdateFollowDuration.value ~/ 60,
+        minute: controller.appC.autoUpdateFollowDuration.value % 60,
       ),
       initialEntryMode: TimePickerEntryMode.inputOnly,
       builder: (_, child) {
@@ -94,7 +94,7 @@ class FollowSettingsPage extends GetView<AppSettingsController> {
       return;
     }
     var duration = Duration(hours: value.hour, minutes: value.minute);
-    controller.setAutoUpdateFollowDuration(duration.inMinutes);
+    controller.appC.setAutoUpdateFollowDuration(duration.inMinutes);
     FollowService.instance.initTimer();
   }
 }

--- a/simple_live_app/lib/modules/follow_user/follow_app_setting/follow_app_settings_page.dart
+++ b/simple_live_app/lib/modules/follow_user/follow_app_setting/follow_app_settings_page.dart
@@ -45,6 +45,27 @@ class FollowSettingsPage extends GetView<FollowAppSettingsController> {
               Padding(
                 padding: AppStyle.edgeInsetsA12.copyWith(top: 24),
                 child: Text(
+                  "关注清理功能",
+                  style: Get.textTheme.titleSmall,
+                ),
+              ),
+              SettingsCard(
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    SettingsAction(
+                      title: "筛选条件设置：Todo",
+                    ),
+                    SettingsAction(
+                      title: "筛选关注",
+                      onTap: controller.cleanFollow,
+                    ),
+                  ],
+                ),
+              ),
+              Padding(
+                padding: AppStyle.edgeInsetsA12.copyWith(top: 24),
+                child: Text(
                   "自动更新设置",
                   style: Get.textTheme.titleSmall,
                 ),

--- a/simple_live_app/lib/modules/follow_user/follow_app_setting/follow_app_settings_page.dart
+++ b/simple_live_app/lib/modules/follow_user/follow_app_setting/follow_app_settings_page.dart
@@ -1,10 +1,12 @@
 ﻿import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import 'package:simple_live_app/app/app_style.dart';
+import 'package:simple_live_app/models/db/follow_user.dart';
 import 'package:simple_live_app/modules/follow_user/follow_app_setting/follow_app_settings_controller.dart';
 import 'package:simple_live_app/services/follow_service.dart';
 import 'package:simple_live_app/widgets/settings/settings_action.dart';
 import 'package:simple_live_app/widgets/settings/settings_card.dart';
+import 'package:simple_live_app/widgets/settings/settings_menu_check.dart';
 import 'package:simple_live_app/widgets/settings/settings_number.dart';
 import 'package:simple_live_app/widgets/settings/settings_switch.dart';
 
@@ -53,13 +55,24 @@ class FollowSettingsPage extends GetView<FollowAppSettingsController> {
                 child: Column(
                   mainAxisSize: MainAxisSize.min,
                   children: [
-                    SettingsAction(
-                      title: "筛选条件设置：Todo",
-                    ),
-                    SettingsAction(
-                      title: "筛选关注",
-                      onTap: controller.cleanFollow,
-                    ),
+                    // todo：筛选条件设置
+                    // SettingsAction(
+                    //   title: "筛选条件设置",
+                    // ),
+                    SettingsMenuCheck<FollowUser>(
+                      title: '选择要清理的用户',
+                      confirmText: '清理',
+                      itemToString: (user) => user.userName, // 告诉组件如何显示用户名
+
+                      // 这里传入您自己的筛选函数
+                      itemsProvider: () async {
+                        return controller.buildAutoCleanPool();
+                      },
+                      // 用户点击“清理”按钮后的回调
+                      onConfirm: (List<FollowUser> selectedUsers) {
+                        controller.cleanFollow(selectedUsers);
+                      },
+                    )
                   ],
                 ),
               ),

--- a/simple_live_app/lib/modules/follow_user/follow_app_setting/follow_app_settings_page.dart
+++ b/simple_live_app/lib/modules/follow_user/follow_app_setting/follow_app_settings_page.dart
@@ -20,53 +20,84 @@ class FollowSettingsPage extends GetView<FollowAppSettingsController> {
       body: ListView(
         padding: AppStyle.edgeInsetsA12,
         children: [
-          SettingsCard(
-            child: Column(
-              children: [
-                Obx(
-                      () => SettingsSwitch(
-                    value: controller.appC.autoUpdateFollowEnable.value,
-                    title: "自动更新关注直播状态",
-                    onChanged: (e) {
-                      controller.appC.setAutoUpdateFollowEnable(e);
-                      FollowService.instance.initTimer();
-                    },
-                  ),
+          Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              Padding(
+                padding: AppStyle.edgeInsetsA12.copyWith(top: 0),
+                child: Text(
+                  "标签管理",
+                  style: Get.textTheme.titleSmall,
                 ),
-                Obx(
-                      () => Visibility(
-                    visible: controller.appC.autoUpdateFollowEnable.value,
-                    child: AppStyle.divider,
-                  ),
-                ),
-                Obx(
-                      () => Visibility(
-                    visible: controller.appC.autoUpdateFollowEnable.value,
-                    child: SettingsAction(
-                      title: "自动更新间隔",
-                      value:
-                      "${controller.appC.autoUpdateFollowDuration.value ~/ 60}小时${controller.appC.autoUpdateFollowDuration.value % 60}分钟",
-                      onTap: () {
-                        setTimer(context);
-                      },
+              ),
+              SettingsCard(
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    SettingsAction(
+                      title: "标签管理",
+                      onTap: controller.showTagsManager,
                     ),
-                  ),
+                  ],
                 ),
-                AppStyle.divider,
-                Obx(
+              ),
+              Padding(
+                padding: AppStyle.edgeInsetsA12.copyWith(top: 24),
+                child: Text(
+                  "自动更新设置",
+                  style: Get.textTheme.titleSmall,
+                ),
+              ),
+              SettingsCard(
+                child: Column(
+                  children: [
+                    Obx(
+                      () => SettingsSwitch(
+                        value: controller.appC.autoUpdateFollowEnable.value,
+                        title: "自动更新关注直播状态",
+                        onChanged: (e) {
+                          controller.appC.setAutoUpdateFollowEnable(e);
+                          FollowService.instance.initTimer();
+                        },
+                      ),
+                    ),
+                    Obx(
+                      () => Visibility(
+                        visible: controller.appC.autoUpdateFollowEnable.value,
+                        child: AppStyle.divider,
+                      ),
+                    ),
+                    Obx(
+                      () => Visibility(
+                        visible: controller.appC.autoUpdateFollowEnable.value,
+                        child: SettingsAction(
+                          title: "自动更新间隔",
+                          value:
+                              "${controller.appC.autoUpdateFollowDuration.value ~/ 60}小时${controller.appC.autoUpdateFollowDuration.value % 60}分钟",
+                          onTap: () {
+                            setTimer(context);
+                          },
+                        ),
+                      ),
+                    ),
+                    AppStyle.divider,
+                    Obx(
                       () => SettingsNumber(
-                    value: controller.appC.updateFollowThreadCount.value,
-                    title: "更新线程数",
-                    subtitle: "多线程可以能更快的完成加载，但可能会因为请求太频繁导致读取状态失败",
-                    min: 1,
-                    max: 12,
-                    onChanged: (e) {
-                      controller.appC.setUpdateFollowThreadCount(e);
-                    },
-                  ),
+                        value: controller.appC.updateFollowThreadCount.value,
+                        title: "更新线程数",
+                        subtitle: "多线程可以能更快的完成加载，但可能会因为请求太频繁导致读取状态失败",
+                        min: 1,
+                        max: 12,
+                        onChanged: (e) {
+                          controller.appC.setUpdateFollowThreadCount(e);
+                        },
+                      ),
+                    ),
+                  ],
                 ),
-              ],
-            ),
+              ),
+            ],
           ),
         ],
       ),

--- a/simple_live_app/lib/modules/follow_user/follow_user_controller.dart
+++ b/simple_live_app/lib/modules/follow_user/follow_user_controller.dart
@@ -120,43 +120,8 @@ class FollowUserController extends BasePageController<FollowUser> {
     filterData();
   }
 
-  Future removeTag(FollowUserTag tag) async {
-    await FollowService.instance.removeFollowUserTag(tag);
-    updateTagList();
-    Log.i('删除tag${tag.tag}');
-  }
-
-  void addTag(String tag) async {
-    await FollowService.instance.addFollowUserTag(tag);
-    updateTagList();
-  }
-
   Future<void> updateTag(FollowUserTag followUserTag) async {
     await FollowService.instance.updateFollowUserTag(followUserTag);
-  }
-
-  void updateTagName(FollowUserTag followUserTag, String newTagName) {
-    // 未操作
-    if (followUserTag.tag == newTagName) {
-      return;
-    }
-    // 避免重名
-    if (tagList.any((item) => item.tag == newTagName)) {
-      SmartDialog.showToast("标签名重复，修改失败");
-      return;
-    }
-    FollowService.instance.updateTagName(followUserTag, newTagName);
-    SmartDialog.showToast("标签名修改成功");
-    updateTagList();
-  }
-
-  void updateTagOrder(int oldIndex, int newIndex) {
-    if (newIndex > oldIndex) newIndex -= 1; // 处理索引调整
-    final item = userTagList.removeAt(oldIndex);
-    userTagList.insert(newIndex, item);
-    tagList.value = tagList.take(3).toList();
-    tagList.addAll(userTagList);
-    FollowService.instance.updateFollowTagOrder(userTagList);
   }
 
   @override

--- a/simple_live_app/lib/modules/follow_user/follow_user_page.dart
+++ b/simple_live_app/lib/modules/follow_user/follow_user_page.dart
@@ -8,6 +8,7 @@ import 'package:simple_live_app/models/db/follow_user.dart';
 import 'package:simple_live_app/models/db/follow_user_tag.dart';
 import 'package:simple_live_app/modules/follow_user/follow_user_controller.dart';
 import 'package:simple_live_app/routes/app_navigation.dart';
+import 'package:simple_live_app/routes/route_path.dart';
 import 'package:simple_live_app/services/follow_service.dart';
 import 'package:simple_live_app/widgets/filter_button.dart';
 import 'package:simple_live_app/widgets/follow_user_item.dart';
@@ -76,9 +77,9 @@ class FollowUserPage extends GetView<FollowUserController> {
                   child: Row(
                     mainAxisSize: MainAxisSize.min,
                     children: [
-                      Icon(Remix.price_tag_line),
+                      Icon(Remix.heart_line),
                       AppStyle.hGap12,
-                      Text("标签管理"),
+                      Text("关注设置"),
                     ],
                   ),
                 ),
@@ -94,7 +95,7 @@ class FollowUserPage extends GetView<FollowUserController> {
               } else if (value == 3) {
                 FollowService.instance.inputText();
               } else if (value == 4) {
-                showTagsManager();
+                Get.toNamed(RoutePath.kSettingsFollow);
               }
             },
           ),

--- a/simple_live_app/lib/modules/follow_user/follow_user_page.dart
+++ b/simple_live_app/lib/modules/follow_user/follow_user_page.dart
@@ -3,7 +3,6 @@ import 'package:get/get.dart';
 import 'package:remixicon/remixicon.dart';
 import 'package:simple_live_app/app/app_style.dart';
 import 'package:simple_live_app/app/sites.dart';
-import 'package:simple_live_app/app/utils.dart';
 import 'package:simple_live_app/models/db/follow_user.dart';
 import 'package:simple_live_app/models/db/follow_user_tag.dart';
 import 'package:simple_live_app/modules/follow_user/follow_user_controller.dart';
@@ -132,8 +131,9 @@ class FollowUserPage extends GetView<FollowUserController> {
                     () => SingleChildScrollView(
                       scrollDirection: Axis.horizontal,
                       child: Wrap(
-                          spacing: 12,
-                          children: controller.tagList.map((option) {
+                        spacing: 12,
+                        children: controller.tagList.map(
+                          (option) {
                             return FilterButton(
                               text: option.tag,
                               selected: controller.filterMode.value == option,
@@ -141,7 +141,9 @@ class FollowUserPage extends GetView<FollowUserController> {
                                 controller.setFilterMode(option);
                               },
                             );
-                          }).toList()),
+                          },
+                        ).toList(),
+                      ),
                     ),
                   ),
                 ),
@@ -288,141 +290,6 @@ class FollowUserPage extends GetView<FollowUserController> {
               },
             ),
           ],
-        ),
-      ),
-    );
-  }
-
-  void showTagsManager() {
-    Utils.showBottomSheet(
-      title: '标签管理',
-      child: Column(
-          mainAxisSize: MainAxisSize.min,
-          crossAxisAlignment: CrossAxisAlignment.stretch,
-          children: [
-            AppStyle.divider,
-            ListTile(
-              title: const Text("添加标签"),
-              leading: const Icon(Icons.add),
-              onTap: () {
-                editTagDialog("添加标签");
-              },
-            ),
-            AppStyle.divider,
-            // 列表内容
-            Expanded(
-              child: Obx(
-                () => ReorderableListView.builder(
-                  buildDefaultDragHandles: false,
-                  itemCount: controller.userTagList.length,
-                  itemBuilder: (context, index) {
-                    // 偏移
-                    FollowUserTag item = controller.userTagList[index];
-                    return ListTile(
-                      key: ValueKey(item.id),
-                      title: GestureDetector(
-                        child: Text(item.tag),
-                        onLongPress: () {
-                          {
-                            editTagDialog("修改标签", followUserTag: item);
-                          }
-                        },
-                      ),
-                      leading: IconButton(
-                        icon: const Icon(Icons.delete),
-                        onPressed: () {
-                          controller.removeTag(item);
-                        },
-                      ),
-                      trailing: ReorderableDelayedDragStartListener(
-                        index: index,
-                        child: const Padding(
-                          padding: EdgeInsets.symmetric(horizontal: 12.0),
-                          child: Icon(Icons.drag_handle),
-                        ),
-                      ),
-                    );
-                  },
-                  onReorder: (int oldIndex, int newIndex) {
-                    controller.updateTagOrder(oldIndex, newIndex);
-                  },
-                ),
-              ),
-            ),
-          ]),
-    );
-  }
-
-  void editTagDialog(String title, {FollowUserTag? followUserTag}) {
-    final TextEditingController tagEditController =
-        TextEditingController(text: followUserTag?.tag);
-    bool upMode = title == "添加标签" ? true : false;
-    Get.dialog(
-      AlertDialog(
-        contentPadding: const EdgeInsets.all(16.0),
-        shape: RoundedRectangleBorder(
-          borderRadius: BorderRadius.circular(12.0),
-        ),
-        content: SingleChildScrollView(
-          padding: EdgeInsets.only(
-              bottom: MediaQuery.of(Get.context!).viewInsets.bottom),
-          child: Column(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              Text(
-                title,
-                style: const TextStyle(
-                  fontSize: 18,
-                ),
-              ),
-              TextField(
-                controller: tagEditController,
-                minLines: 1,
-                maxLines: 1,
-                decoration: InputDecoration(
-                  border: const OutlineInputBorder(),
-                  contentPadding: AppStyle.edgeInsetsA12,
-                  enabledBorder: OutlineInputBorder(
-                    borderSide: BorderSide(
-                      color: Colors.grey.withValues(alpha: .2),
-                    ),
-                  ),
-                ),
-                onSubmitted: (tag) {
-                  upMode
-                      ? controller.addTag(tagEditController.text)
-                      : controller.updateTagName(
-                          followUserTag!, tagEditController.text);
-                  Get.back();
-                },
-              ),
-              Container(
-                margin: AppStyle.edgeInsetsB4,
-                width: double.infinity,
-                child: Row(
-                  mainAxisAlignment: MainAxisAlignment.end,
-                  children: [
-                    TextButton(
-                      onPressed: () {
-                        Get.back();
-                      },
-                      child: const Text('否'),
-                    ),
-                    TextButton(
-                      onPressed: () {
-                        upMode
-                            ? controller.addTag(tagEditController.text)
-                            : controller.updateTagName(
-                                followUserTag!, tagEditController.text);
-                        Get.back();
-                      },
-                      child: const Text('是'),
-                    ),
-                  ],
-                ),
-              )
-            ],
-          ),
         ),
       ),
     );

--- a/simple_live_app/lib/modules/mine/mine_page.dart
+++ b/simple_live_app/lib/modules/mine/mine_page.dart
@@ -175,17 +175,6 @@ class MinePage extends StatelessWidget {
                   },
                 ),
                 ListTile(
-                  leading: const Icon(Remix.heart_line),
-                  title: const Text("关注设置"),
-                  trailing: const Icon(
-                    Icons.chevron_right,
-                    color: Colors.grey,
-                  ),
-                  onTap: () {
-                    Get.toNamed(RoutePath.kSettingsFollow);
-                  },
-                ),
-                ListTile(
                   leading: const Icon(Remix.timer_2_line),
                   title: const Text("定时关闭"),
                   trailing: const Icon(

--- a/simple_live_app/lib/routes/app_pages.dart
+++ b/simple_live_app/lib/routes/app_pages.dart
@@ -3,48 +3,49 @@
 import 'package:get/get.dart';
 import 'package:simple_live_app/modules/category/detail/category_detail_controller.dart';
 import 'package:simple_live_app/modules/category/detail/category_detail_page.dart';
+import 'package:simple_live_app/modules/follow_user/follow_app_setting/follow_app_settings_controller.dart';
+import 'package:simple_live_app/modules/follow_user/follow_app_setting/follow_app_settings_page.dart';
+import 'package:simple_live_app/modules/follow_user/follow_info_setting/follow_info_controller.dart';
+import 'package:simple_live_app/modules/follow_user/follow_info_setting/follow_info_page.dart';
+import 'package:simple_live_app/modules/follow_user/follow_user_controller.dart';
+import 'package:simple_live_app/modules/follow_user/follow_user_page.dart';
 import 'package:simple_live_app/modules/indexed/indexed_controller.dart';
 import 'package:simple_live_app/modules/live_room/live_room_controller.dart';
 import 'package:simple_live_app/modules/live_room/live_room_page.dart';
-import 'package:simple_live_app/modules/settings/follow_settings_page.dart';
-import 'package:simple_live_app/modules/sync/remote_sync/webdav/remote_sync_webdav_config_page.dart';
-import 'package:simple_live_app/modules/sync/remote_sync/webdav/remote_sync_webdav_controller.dart';
-import 'package:simple_live_app/modules/sync/remote_sync/webdav/remote_sync_webdav_page.dart';
-import 'package:simple_live_app/modules/sync/sync_page.dart';
-import 'package:simple_live_app/modules/sync/remote_sync/room/remote_sync_room_controller.dart';
-import 'package:simple_live_app/modules/sync/remote_sync/room/remote_sync_room_page.dart';
-import 'package:simple_live_app/modules/search/search_controller.dart';
-import 'package:simple_live_app/modules/search/search_page.dart';
-import 'package:simple_live_app/modules/sync/local_sync/device/sync_device_controller.dart';
-import 'package:simple_live_app/modules/sync/local_sync/device/sync_device_page.dart';
-import 'package:simple_live_app/modules/sync/local_sync/scan_qr/sync_scan_qr_controller.dart';
-import 'package:simple_live_app/modules/sync/local_sync/scan_qr/sync_scan_qr_page.dart';
-import 'package:simple_live_app/modules/mine/parse/parse_controller.dart';
-import 'package:simple_live_app/modules/mine/parse/parse_page.dart';
-import 'package:simple_live_app/modules/sync/local_sync/local_sync_controller.dart';
-import 'package:simple_live_app/modules/sync/local_sync/local_sync_page.dart';
 import 'package:simple_live_app/modules/mine/account/account_controller.dart';
 import 'package:simple_live_app/modules/mine/account/account_page.dart';
 import 'package:simple_live_app/modules/mine/account/bilibili/qr_login_controller.dart';
 import 'package:simple_live_app/modules/mine/account/bilibili/qr_login_page.dart';
 import 'package:simple_live_app/modules/mine/account/bilibili/web_login_controller.dart';
 import 'package:simple_live_app/modules/mine/account/bilibili/web_login_page.dart';
+import 'package:simple_live_app/modules/mine/history/history_controller.dart';
+import 'package:simple_live_app/modules/mine/history/history_page.dart';
+import 'package:simple_live_app/modules/mine/parse/parse_controller.dart';
+import 'package:simple_live_app/modules/mine/parse/parse_page.dart';
+import 'package:simple_live_app/modules/search/search_controller.dart';
+import 'package:simple_live_app/modules/search/search_page.dart';
 import 'package:simple_live_app/modules/settings/appstyle_setting_page.dart';
 import 'package:simple_live_app/modules/settings/auto_exit_settings_page.dart';
 import 'package:simple_live_app/modules/settings/danmu_settings_page.dart';
 import 'package:simple_live_app/modules/settings/danmu_shield/danmu_shield_controller.dart';
 import 'package:simple_live_app/modules/settings/danmu_shield/danmu_shield_page.dart';
-import 'package:simple_live_app/modules/follow_user/follow_user_controller.dart';
-import 'package:simple_live_app/modules/follow_user/follow_user_page.dart';
-import 'package:simple_live_app/modules/mine/history/history_controller.dart';
-import 'package:simple_live_app/modules/mine/history/history_page.dart';
 import 'package:simple_live_app/modules/settings/indexed_settings/indexed_settings_controller.dart';
 import 'package:simple_live_app/modules/settings/indexed_settings/indexed_settings_page.dart';
 import 'package:simple_live_app/modules/settings/other/other_settings_controller.dart';
 import 'package:simple_live_app/modules/settings/other/other_settings_page.dart';
 import 'package:simple_live_app/modules/settings/play_settings_page.dart';
-import 'package:simple_live_app/modules/follow_user/follow_info_setting/follow_info_controller.dart';
-import 'package:simple_live_app/modules/follow_user/follow_info_setting/follow_info_page.dart';
+import 'package:simple_live_app/modules/sync/local_sync/device/sync_device_controller.dart';
+import 'package:simple_live_app/modules/sync/local_sync/device/sync_device_page.dart';
+import 'package:simple_live_app/modules/sync/local_sync/local_sync_controller.dart';
+import 'package:simple_live_app/modules/sync/local_sync/local_sync_page.dart';
+import 'package:simple_live_app/modules/sync/local_sync/scan_qr/sync_scan_qr_controller.dart';
+import 'package:simple_live_app/modules/sync/local_sync/scan_qr/sync_scan_qr_page.dart';
+import 'package:simple_live_app/modules/sync/remote_sync/room/remote_sync_room_controller.dart';
+import 'package:simple_live_app/modules/sync/remote_sync/room/remote_sync_room_page.dart';
+import 'package:simple_live_app/modules/sync/remote_sync/webdav/remote_sync_webdav_config_page.dart';
+import 'package:simple_live_app/modules/sync/remote_sync/webdav/remote_sync_webdav_controller.dart';
+import 'package:simple_live_app/modules/sync/remote_sync/webdav/remote_sync_webdav_page.dart';
+import 'package:simple_live_app/modules/sync/sync_page.dart';
 
 import '../modules/indexed/indexed_page.dart';
 import 'route_path.dart';
@@ -249,6 +250,9 @@ class AppPages {
     GetPage(
       name: RoutePath.kSettingsFollow,
       page: () => const FollowSettingsPage(),
+      bindings: [
+        BindingsBuilder.put(() => FollowAppSettingsController()),
+      ],
     ),
     // 关注用户-信息详情
     GetPage(

--- a/simple_live_app/lib/services/follow_service.dart
+++ b/simple_live_app/lib/services/follow_service.dart
@@ -18,6 +18,7 @@ import 'package:simple_live_app/models/db/follow_user.dart';
 import 'package:simple_live_app/models/db/follow_user_tag.dart';
 import 'package:simple_live_app/models/db/history.dart';
 import 'package:simple_live_app/services/db_service.dart';
+import 'package:simple_live_core/simple_live_core.dart';
 import 'package:synchronized/synchronized.dart';
 
 class FollowService extends GetxService {
@@ -55,6 +56,10 @@ class FollowService extends GetxService {
 
   Timer? updateTimer;
 
+  int _totalToUpdate = 0;
+
+  int _refreshCycle = 0;
+
   @override
   void onInit() {
     subscription = EventBus.instance.listen(Constant.kUpdateFollow, (data) {
@@ -68,7 +73,7 @@ class FollowService extends GetxService {
     super.onInit();
   }
 
-  void updateTagName(FollowUserTag followUserTag, String newTagName){
+  void updateTagName(FollowUserTag followUserTag, String newTagName) {
     final FollowUserTag newTag = followUserTag.copyWith(tag: newTagName);
     updateFollowUserTag(newTag);
     // update item's tag when update tagName
@@ -81,7 +86,7 @@ class FollowService extends GetxService {
     }
   }
 
-  Future<void> updateFollowUserTag(FollowUserTag tag) async{
+  Future<void> updateFollowUserTag(FollowUserTag tag) async {
     if (tag.tag == '全部') {
       return;
     }
@@ -216,7 +221,7 @@ class FollowService extends GetxService {
   }
 
   // 判断关注是否存在
-  bool getFollowExist(String id){
+  bool getFollowExist(String id) {
     return DBService.instance.getFollowExist(id);
   }
 
@@ -236,13 +241,15 @@ class FollowService extends GetxService {
   void initTimer() {
     if (AppSettingsController.instance.autoUpdateFollowEnable.value) {
       updateTimer?.cancel();
+      _refreshCycle = 0;
       updateTimer = Timer.periodic(
         Duration(
             minutes:
                 AppSettingsController.instance.autoUpdateFollowDuration.value),
         (timer) {
-          Log.logPrint("Update Follow Timer");
-          loadData();
+          CoreLog.i("Update Follow Timer - Cycle: $_refreshCycle");
+          loadData(updateStatus: true, cycle: _refreshCycle);
+          _refreshCycle = (_refreshCycle + 1) % 2; // 2-cycle rotation
         },
       );
     } else {
@@ -250,23 +257,102 @@ class FollowService extends GetxService {
     }
   }
 
-  Future<void> loadData({bool updateStatus = true}) async {
+  Future<void> loadData({bool updateStatus = true, int? cycle}) async {
     var list = DBService.instance.getFollowList();
     getAllTagList();
     if (list.isEmpty) {
       updating.value = false;
       followList.assignAll(list);
+      liveList.clear();
+      notLiveList.clear();
+      _updatedListController.add(0);
       return;
     }
     followList.assignAll(list);
     if (updateStatus) {
-      startUpdateStatus();
+      startUpdateStatus(cycle: cycle);
     }
   }
 
-  void startUpdateStatus() async {
+  void multiRoundPriority() {
+    final historyList = DBService.instance.getHistories();
+    final Map<String, int> historyRankMap = {
+      for (var i = 0; i < historyList.length; i++) historyList[i].id: i
+    };
+    final int maxRank = historyList.isNotEmpty ? historyList.length : 1;
+
+    Duration maxDuration = const Duration();
+    for (var user in followList) {
+      final duration = user.watchDuration!.toDuration();
+      if (duration > maxDuration) {
+        maxDuration = duration;
+      }
+    }
+    final double maxDurationInSeconds =
+        maxDuration.inSeconds > 0 ? maxDuration.inSeconds.toDouble() : 1.0;
+    // 简单线性加权组合算法，目前认定观看时长和最近观看时间权重一致
+    // 如果用户历史行为序列非常长：可替换为时间衰减 + 观看时长加权
+    followList.sort((a, b) {
+      // 静态权重
+      const double wDuration = 0.5;
+      const double wRecency = 0.5;
+
+      double normDurationA =
+          a.watchDuration!.toDuration().inSeconds.toDouble() /
+              maxDurationInSeconds;
+      int rankA = historyRankMap[a.id] ?? maxRank;
+      double normRecencyA = (maxRank - rankA).toDouble() / maxRank;
+      double scoreA = (wDuration * normDurationA) + (wRecency * normRecencyA);
+
+      double normDurationB =
+          b.watchDuration!.toDuration().inSeconds.toDouble() /
+              maxDurationInSeconds;
+      int rankB = historyRankMap[b.id] ?? maxRank;
+      double normRecencyB = (maxRank - rankB).toDouble() / maxRank;
+      double scoreB = (wDuration * normDurationB) + (wRecency * normRecencyB);
+
+      return scoreB.compareTo(scoreA);
+    });
+  }
+
+  void startUpdateStatus({int? cycle}) async {
+    List<FollowUser> usersToUpdate;
+    final totalUsers = followList.length;
+
+    if (cycle != null && totalUsers > 100) {
+      // 简单28
+      final topNCount = (totalUsers * 0.2).round(); // Top 50%
+      final bottomNCount = (totalUsers * 0.2).round(); // Bottom 20%
+      final middlePartEndIndex = totalUsers - bottomNCount;
+      multiRoundPriority();
+      final topNUsers = followList.sublist(0, topNCount);
+      final middleUsers = followList.sublist(topNCount, middlePartEndIndex);
+      if (cycle == 0) {
+        usersToUpdate = topNUsers;
+        CoreLog.i(
+            "Update Follow: Cycle 0, updating top ${usersToUpdate.length}/$totalUsers users.");
+      } else {
+        usersToUpdate = [...topNUsers, ...middleUsers];
+        CoreLog.i(
+            "Update Follow: Cycle 1, updating top+middle ${usersToUpdate.length}/$totalUsers users.");
+      }
+    } else {
+      usersToUpdate = List.from(followList);
+      if (cycle != null) {
+        CoreLog.i(
+            "Update Follow: List <= 100, updating all ${usersToUpdate.length} users.");
+      }
+    }
+
+    _totalToUpdate = usersToUpdate.length;
     updatedCount = 0;
     updating.value = true;
+
+    if (_totalToUpdate == 0) {
+      updating.value = false;
+      filterData();
+      return;
+    }
 
     var threadCount =
         AppSettingsController.instance.updateFollowThreadCount.value;
@@ -275,14 +361,13 @@ class FollowService extends GetxService {
     for (var i = 0; i < threadCount; i++) {
       tasks.add(
         Future(() async {
-          var start = i * followList.length ~/ threadCount;
-          var end = (i + 1) * followList.length ~/ threadCount;
+          var start = i * usersToUpdate.length ~/ threadCount;
+          var end = (i + 1) * usersToUpdate.length ~/ threadCount;
 
-          // 确保 end 不超出列表长度
-          if (end > followList.length) {
-            end = followList.length;
+          if (end > usersToUpdate.length) {
+            end = usersToUpdate.length;
           }
-          var items = followList.sublist(start, end);
+          var items = usersToUpdate.sublist(start, end);
           for (var item in items) {
             await updateLiveStatus(item);
           }
@@ -303,7 +388,7 @@ class FollowService extends GetxService {
       await _lock.synchronized(() {
         updatedCount++;
       });
-      if (updatedCount >= followList.length) {
+      if (updatedCount >= _totalToUpdate) {
         filterData();
         updating.value = false;
       }

--- a/simple_live_app/lib/services/history_service.dart
+++ b/simple_live_app/lib/services/history_service.dart
@@ -56,7 +56,7 @@ class HistoryService extends GetxService {
       curLiveRoomHistory = history;
       DBService.instance.addOrUpdateHistory(history);
     }
-    _oldWatchedDuration = curLiveRoomHistory!.watchDuration!.toDuration();
+    _oldWatchedDuration = curLiveRoomHistory!.duration;
   }
 
   // updateHistory

--- a/simple_live_app/lib/widgets/settings/settings_menu_check.dart
+++ b/simple_live_app/lib/widgets/settings/settings_menu_check.dart
@@ -1,0 +1,181 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_smart_dialog/flutter_smart_dialog.dart';
+import 'package:get/get.dart';
+import 'package:remixicon/remixicon.dart';
+import 'package:simple_live_app/app/app_style.dart';
+
+class _MenuCheckController<T> extends GetxController {
+  final RxList<T> selectedItems;
+
+  _MenuCheckController(List<T> initial) : selectedItems = RxList<T>.from(initial);
+
+  void toggle(T item) {
+    if (selectedItems.contains(item)) {
+      selectedItems.remove(item);
+    } else {
+      selectedItems.add(item);
+    }
+  }
+}
+
+class SettingsMenuCheck<T> extends StatelessWidget {
+  final String title;
+  final String? subtitle;
+  final List<T> items;
+  final List<T> initialSelection;
+  final Future<List<T>> Function()? itemsProvider;
+  final List<T> Function(List<T> providedItems)? initialSelectionProvider;
+
+  final String Function(T item) itemToString;
+  final Function(List<T> selectedItems)? onConfirm;
+  final String? confirmText;
+  final String? modalTitle;
+
+  const SettingsMenuCheck({
+    required this.title,
+    required this.itemToString,
+    this.items = const [],
+    this.initialSelection = const [],
+    this.itemsProvider,
+    this.initialSelectionProvider,
+    this.subtitle,
+    this.onConfirm,
+    this.confirmText,
+    this.modalTitle,
+    Key? key,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    // 这里需要状态管理，暂时不实现
+    final displayItemsCount = items.length;
+    final displaySelectedCount = initialSelection.length;
+
+    return ListTile(
+      visualDensity: VisualDensity.compact,
+      title: Text(
+        title,
+        style: Theme.of(context).textTheme.bodyLarge,
+      ),
+      shape: RoundedRectangleBorder(
+        borderRadius: AppStyle.radius8,
+      ),
+      contentPadding: AppStyle.edgeInsetsL16.copyWith(right: 8),
+      subtitle: subtitle == null
+          ? null
+          : Text(
+              subtitle!,
+              style: Get.textTheme.bodySmall!.copyWith(color: Colors.grey),
+            ),
+      trailing: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Text(
+            '$displaySelectedCount/$displayItemsCount',
+            style: Theme.of(context)
+                .textTheme
+                .bodyMedium!
+                .copyWith(color: Colors.grey),
+          ),
+          AppStyle.hGap4,
+          const Icon(
+            Icons.chevron_right,
+            color: Colors.grey,
+          ),
+        ],
+      ),
+      onTap: _handleTap,
+    );
+  }
+
+  Future<void> _handleTap() async {
+    List<T> menuItems;
+    List<T> menuInitialSelection;
+    if (itemsProvider != null) {
+      SmartDialog.showLoading(msg: "");
+      try {
+        menuItems = await itemsProvider!();
+        if (initialSelectionProvider != null) {
+          menuInitialSelection = initialSelectionProvider!(menuItems);
+        } else {
+          menuInitialSelection = menuItems.toList();
+        }
+      } finally {
+        SmartDialog.dismiss();
+      }
+    } else {
+      menuItems = items;
+      menuInitialSelection = initialSelection;
+    }
+
+    if (menuItems.isEmpty) {
+      return;
+    }
+
+    _openMenu(Get.context!, menuItems, menuInitialSelection);
+  }
+
+  void _openMenu(
+      BuildContext context, List<T> items, List<T> initialSelection) {
+    final controller = _MenuCheckController<T>(initialSelection);
+
+    showModalBottomSheet(
+      context: context,
+      isScrollControlled: true,
+      showDragHandle: false,
+      useSafeArea: true,
+      constraints: BoxConstraints(
+        maxWidth: 600,
+      ),
+      shape: const RoundedRectangleBorder(
+        borderRadius: BorderRadius.only(
+          topLeft: Radius.circular(12),
+          topRight: Radius.circular(12),
+        ),
+      ),
+      builder: (_) {
+        return SafeArea(
+          top: false,
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              ListTile(
+                contentPadding: const EdgeInsets.only(
+                  left: 12,
+                ),
+                title: Text(modalTitle?.tr ?? title.tr,),
+                trailing: IconButton(
+                  onPressed: () {
+                    Get.back();
+                    onConfirm?.call(controller.selectedItems.toList());
+                  },
+                  icon: const Icon(Remix.delete_bin_line),
+                ),
+              ),
+              Flexible(
+                child: SingleChildScrollView(
+                  child: Column(
+                    mainAxisSize: MainAxisSize.min,
+                    children: items.map((item) {
+                      return Obx(() => CheckboxListTile(
+                            value: controller.selectedItems.contains(item),
+                            controlAffinity: ListTileControlAffinity.leading,
+                            title: Text(
+                              itemToString(item),
+                              style: Get.textTheme.bodyMedium,
+                            ),
+                            onChanged: (bool? selected) {
+                              controller.toggle(item);
+                            },
+                          ));
+                    }).toList(),
+                  ),
+                ),
+              ),
+            ],
+          ),
+        );
+      },
+    );
+  }
+}


### PR DESCRIPTION
https://github.com/SlotSun/dart_simple_live/issues/34#issue-3421152565

## Sourcery 总结

通过引入专门的关注设置、用户列表和信息页面，并配备相应的路由和控制器，将关注相关功能模块化，以及简化到新关注设置模块的导航。

新功能：
- 引入 FollowAppSettingsPage 和 FollowAppSettingsController，以封装关注相关的设置
- 在 AppPages 中注册关注用户列表、关注信息详情和关注设置路由，并进行适当的绑定

改进：
- 重构 FollowSettingsPage，通过新的包装控制器将设置操作委托给 AppSettingsController
- 从 MinePage 中移除旧的关注设置入口，并更新 FollowUserPage 以导航到新的设置页面

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Modularize follow-related features by introducing dedicated follow settings, user list, and info pages with appropriate routing and controllers, and streamline navigation to the new follow settings module

New Features:
- Introduce FollowAppSettingsPage and FollowAppSettingsController to encapsulate follow-related settings
- Register follow user list, follow info detail, and follow settings routes in AppPages with proper bindings

Enhancements:
- Refactor FollowSettingsPage to delegate setting operations to AppSettingsController via the new wrapper controller
- Remove the legacy follow settings entry from MinePage and update FollowUserPage to navigate to the new settings page

</details>