### PR TITLE
rename flatpak id

### DIFF
--- a/simple_live_app/assets/io.github.SlotSun.dart_simple_live.desktop
+++ b/simple_live_app/assets/io.github.SlotSun.dart_simple_live.desktop
@@ -2,8 +2,8 @@
 Type=Application
 Name=Slive
 GenericName=Livestream Player
-Icon=io.github.slotsun.slive
-Exec=simple_live_app %U
+Icon=io.github.SlotSun.dart_simple_live
+Exec=Slive %U
 Categories=AudioVideo;Audio;Video;Network
 Keywords=Livestream;Video
 StartupNotify=true

--- a/simple_live_app/assets/io.github.SlotSun.dart_simple_live.metainfo.xml
+++ b/simple_live_app/assets/io.github.SlotSun.dart_simple_live.metainfo.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <component type="desktop">
-  <id>io.github.slotsun.slive</id>
-  <launchable type="desktop-id">io.github.slotsun.slive.desktop</launchable>
+  <id>io.github.SlotSun.dart_simple_live</id>
+  <launchable type="desktop-id">io.github.SlotSun.dart_simple_live.desktop</launchable>
   <name>Slive</name>
-  <developer id="io.github.slotsun">
+  <developer id="io.github.SlotSun">
     <name>SlotSun</name>
   </developer>
   <summary>Watch live streams simply</summary>

--- a/simple_live_app/linux/packaging/deb/make_config.yaml
+++ b/simple_live_app/linux/packaging/deb/make_config.yaml
@@ -26,4 +26,4 @@ startup_notify: true
 dependencies:
   - libmpv2
 
-metainfo: assets/io.github.slotsun.slive.metainfo.xml
+metainfo: assets/io.github.SlotSun.dart_simple_live.metainfo.xml


### PR DESCRIPTION
## Sourcery 总结

重命名 Flathub 包和开发者标识符，并更新相关文件名以使用新的 `io.github.SlotSun.dart_simple_live` 命名方案

改进：
- 更新 metainfo 组件和可启动 ID 为 `io.github.SlotSun.dart_simple_live`
- 在 metainfo XML 中将开发者 ID 的大小写调整为 `io.github.SlotSun`
- 重命名桌面入口文件为 `io.github.SlotSun.dart_simple_live.desktop`

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

将 Flathub 应用程序和开发者标识符重命名为 `io.github.SlotSun.dart_simple_live`，更新相关的资产文件名和打包引用，并将 `media_kit` 依赖项固定到 `main` 分支，同时添加平台特定的覆盖。

增强功能：
- 在 `pubspec.yaml` 中将 `media_kit` 依赖项和相关视频库固定到 `main` 分支，并为 `linux`、`ios`、`android`、`windows` 和 `macOS` 添加覆盖。
- 更新 `metainfo` XML 和桌面入口以使用新的应用程序 ID 和开发者 ID `io.github.SlotSun.dart_simple_live`。
- 重命名 `metainfo` 和桌面资产文件名，并调整打包配置以反映新的命名方案。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

在 Flathub 元数据、桌面入口和打包配置中，采用新的 `io.github.SlotSun.dart_simple_live` 命名方案。

增强：
- 更新 Flathub 元信息 XML，以使用新的应用程序 ID 并修正开发者 ID 的大小写

构建：
- 重命名桌面入口和元信息资产文件名，以匹配新的标识符
- 更新 Debian 打包配置，以引用重命名后的元信息文件

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adopt the new io.github.SlotSun.dart_simple_live naming scheme across Flathub metadata, desktop entry, and packaging configuration

Enhancements:
- Update Flathub metainfo XML to use the new application ID and correct developer ID casing

Build:
- Rename desktop entry and metainfo asset filenames to match the new identifier
- Update Debian packaging config to reference the renamed metainfo file

</details>

</details>

</details>