### PR TITLE
style: restyle Slive with YesPlayMusic-inspired UI

### DIFF
--- a/simple_live_app/integration_test/simple_test.dart
+++ b/simple_live_app/integration_test/simple_test.dart
@@ -1,13 +1,28 @@
+import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:simple_live_app/main.dart';
-import 'package:simple_live_app/src/rust/frb_generated.dart';
 import 'package:integration_test/integration_test.dart';
+import 'package:simple_live_app/app/app_style.dart';
+import 'package:simple_live_app/app/design_system/app_design_tokens.dart';
 
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
-  setUpAll(() async => await RustLib.init());
-  testWidgets('Can call rust function', (WidgetTester tester) async {
-    await tester.pumpWidget(const MyApp());
-    expect(find.textContaining('Result: `Hello, Tom!`'), findsOneWidget);
+
+  testWidgets('visual shell smoke test', (tester) async {
+    final colorScheme = ColorScheme.fromSeed(
+      seedColor: AppDesignTokens.defaultSeedColor,
+    );
+
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: AppStyle.light(colorScheme: colorScheme),
+        home: Scaffold(
+          appBar: AppBar(title: const Text('Slive')),
+          body: const Center(child: Text('visual smoke')),
+        ),
+      ),
+    );
+
+    expect(find.text('Slive'), findsOneWidget);
+    expect(find.text('visual smoke'), findsOneWidget);
   });
 }

--- a/simple_live_app/lib/app/app_style.dart
+++ b/simple_live_app/lib/app/app_style.dart
@@ -1,131 +1,576 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:get/get.dart';
+import 'package:simple_live_app/app/design_system/app_design_tokens.dart';
+import 'package:simple_live_app/app/design_system/app_theme_extension.dart';
 
 class AppColors {
-  static ColorScheme lightColorScheme = ColorScheme.fromSeed(
-    // primarySwatch: Colors.blue,
-    seedColor: const Color(0xff3498db),
-    brightness: Brightness.light,
-  );
-  static ColorScheme darkColorScheme = ColorScheme.fromSeed(
-    seedColor: const Color(0xff3498db),
-    brightness: Brightness.dark,
-  );
-
+  static const Color defaultSeedColor = AppDesignTokens.defaultSeedColor;
   static const Color black333 = Color(0xFF333333);
 }
 
 class AppStyle {
-  static ThemeData light({String? fontFamily}) {
-    return ThemeData(
-      colorScheme: AppColors.lightColorScheme,
-      useMaterial3: true,
+  static ThemeData light({
+    required ColorScheme colorScheme,
+    String? fontFamily,
+  }) {
+    return _buildTheme(
+      brightness: Brightness.light,
+      colorScheme: colorScheme,
       fontFamily: fontFamily,
+    );
+  }
+
+  static ThemeData darkTheme({
+    required ColorScheme colorScheme,
+    String? fontFamily,
+  }) {
+    return _buildTheme(
+      brightness: Brightness.dark,
+      colorScheme: colorScheme,
+      fontFamily: fontFamily,
+    );
+  }
+
+  static ThemeData _buildTheme({
+    required Brightness brightness,
+    required ColorScheme colorScheme,
+    String? fontFamily,
+  }) {
+    final isDark = brightness == Brightness.dark;
+    final semantic = isDark
+        ? AppThemeExtension.dark()
+        : AppThemeExtension.light();
+    final resolvedFontFamily = AppTypography.resolveFontFamily(fontFamily);
+    final resolvedColorScheme = colorScheme.copyWith(
+      brightness: brightness,
+      surface: semantic.body,
+      onSurface: semantic.textPrimary,
+      surfaceContainerLowest: semantic.body,
+      surfaceContainerLow: semantic.secondarySurface,
+      surfaceContainer: semantic.secondarySurface,
+      surfaceContainerHigh: semantic.elevatedSurface,
+      surfaceContainerHighest: semantic.elevatedSurface,
+      surfaceTint: Colors.transparent,
+      outline: semantic.border,
+      outlineVariant: semantic.divider,
+      shadow: semantic.shadow,
+      scrim: Colors.black,
+    );
+    final textTheme = _buildTextTheme(
+      brightness: brightness,
+      fontFamily: resolvedFontFamily,
+      semantic: semantic,
+    );
+    final overlayStyle = (isDark
+            ? SystemUiOverlayStyle.light
+            : SystemUiOverlayStyle.dark)
+        .copyWith(
+      statusBarColor: Colors.transparent,
+      systemNavigationBarColor: Colors.transparent,
+      statusBarIconBrightness:
+          isDark ? Brightness.light : Brightness.dark,
+      systemNavigationBarIconBrightness:
+          isDark ? Brightness.light : Brightness.dark,
+    );
+    final controlShape = RoundedRectangleBorder(
+      borderRadius: BorderRadius.circular(AppDesignTokens.radius8),
+    );
+    final borderedControlShape = RoundedRectangleBorder(
+      borderRadius: BorderRadius.circular(AppDesignTokens.radius8),
+      side: BorderSide(color: semantic.border),
+    );
+
+    return ThemeData(
+      useMaterial3: true,
+      brightness: brightness,
+      colorScheme: resolvedColorScheme,
+      scaffoldBackgroundColor: semantic.body,
+      canvasColor: semantic.body,
+      cardColor: semantic.secondarySurface,
+      dividerColor: semantic.divider,
+      disabledColor: semantic.textDisabled,
+      fontFamily: resolvedFontFamily,
+      textTheme: textTheme,
+      primaryTextTheme: textTheme.apply(
+        bodyColor: resolvedColorScheme.onPrimary,
+        displayColor: resolvedColorScheme.onPrimary,
+      ),
       visualDensity: VisualDensity.standard,
+      extensions: <ThemeExtension<dynamic>>[semantic],
       appBarTheme: AppBarTheme(
-        //elevation: 0,
+        backgroundColor: semantic.body,
+        foregroundColor: semantic.textPrimary,
+        surfaceTintColor: Colors.transparent,
+        shadowColor: Colors.transparent,
+        elevation: 0,
+        scrolledUnderElevation: 0,
         centerTitle: true,
-        titleTextStyle: TextStyle(
-          fontFamily: fontFamily,
-          fontSize: 16,
-          color: AppColors.black333,
+        titleTextStyle: textTheme.titleMedium?.copyWith(
+          color: semantic.textPrimary,
+          fontWeight: FontWeight.w600,
         ),
-        foregroundColor: AppColors.black333,
-        systemOverlayStyle: SystemUiOverlayStyle.dark.copyWith(
-          systemNavigationBarColor: Colors.transparent,
+        iconTheme: IconThemeData(color: semantic.textPrimary),
+        actionsIconTheme: IconThemeData(color: semantic.textPrimary),
+        systemOverlayStyle: overlayStyle,
+      ),
+      cardTheme: CardThemeData(
+        color: semantic.secondarySurface,
+        surfaceTintColor: Colors.transparent,
+        shadowColor: semantic.shadow,
+        elevation: 0,
+        clipBehavior: Clip.antiAlias,
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(AppDesignTokens.radius12),
+          side: BorderSide(color: semantic.border),
         ),
+      ),
+      dialogTheme: DialogThemeData(
+        backgroundColor: semantic.elevatedSurface,
+        surfaceTintColor: Colors.transparent,
+        shadowColor: semantic.shadow,
+        elevation: 8,
+        titleTextStyle: textTheme.titleLarge,
+        contentTextStyle: textTheme.bodyMedium,
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(AppDesignTokens.radius16),
+          side: BorderSide(color: semantic.border),
+        ),
+      ),
+      bottomSheetTheme: BottomSheetThemeData(
+        backgroundColor: semantic.elevatedSurface,
+        modalBackgroundColor: semantic.elevatedSurface,
+        surfaceTintColor: Colors.transparent,
+        shadowColor: semantic.shadow,
+        elevation: 8,
+        modalElevation: 8,
+        shape: const RoundedRectangleBorder(
+          borderRadius: BorderRadius.vertical(
+            top: Radius.circular(AppDesignTokens.radius16),
+          ),
+        ),
+      ),
+      dividerTheme: DividerThemeData(
+        color: semantic.divider,
+        thickness: 1,
+        space: 1,
+      ),
+      listTileTheme: ListTileThemeData(
+        iconColor: semantic.textSecondary,
+        textColor: semantic.textPrimary,
+        subtitleTextStyle: textTheme.bodySmall,
+        contentPadding: const EdgeInsets.symmetric(
+          horizontal: AppDesignTokens.space16,
+        ),
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(AppDesignTokens.radius8),
+        ),
+      ),
+      navigationBarTheme: NavigationBarThemeData(
+        backgroundColor: semantic.body,
+        surfaceTintColor: Colors.transparent,
+        shadowColor: Colors.transparent,
+        elevation: 0,
+        indicatorColor: resolvedColorScheme.primaryContainer,
+        iconTheme: WidgetStateProperty.resolveWith((states) {
+          return IconThemeData(
+            color: states.contains(WidgetState.selected)
+                ? resolvedColorScheme.primary
+                : semantic.textSecondary,
+          );
+        }),
+        labelTextStyle: WidgetStateProperty.resolveWith((states) {
+          return textTheme.labelMedium?.copyWith(
+            color: states.contains(WidgetState.selected)
+                ? resolvedColorScheme.primary
+                : semantic.textSecondary,
+            fontWeight: states.contains(WidgetState.selected)
+                ? FontWeight.w600
+                : FontWeight.w500,
+          );
+        }),
+      ),
+      navigationRailTheme: NavigationRailThemeData(
+        backgroundColor: semantic.body,
+        elevation: 0,
+        indicatorColor: resolvedColorScheme.primaryContainer,
+        selectedIconTheme: IconThemeData(color: resolvedColorScheme.primary),
+        unselectedIconTheme: IconThemeData(color: semantic.textSecondary),
+        selectedLabelTextStyle: textTheme.labelMedium?.copyWith(
+          color: resolvedColorScheme.primary,
+          fontWeight: FontWeight.w600,
+        ),
+        unselectedLabelTextStyle: textTheme.labelMedium,
+      ),
+      bottomNavigationBarTheme: BottomNavigationBarThemeData(
+        backgroundColor: semantic.body,
+        elevation: 0,
+        selectedItemColor: resolvedColorScheme.primary,
+        unselectedItemColor: semantic.textSecondary,
+        selectedLabelStyle: textTheme.labelSmall?.copyWith(
+          fontWeight: FontWeight.w600,
+        ),
+        unselectedLabelStyle: textTheme.labelSmall,
+        type: BottomNavigationBarType.fixed,
+      ),
+      tabBarTheme: TabBarThemeData(
+        labelColor: resolvedColorScheme.primary,
+        unselectedLabelColor: semantic.textSecondary,
+        indicatorColor: resolvedColorScheme.primary,
+        dividerColor: Colors.transparent,
+        overlayColor: WidgetStatePropertyAll(
+          resolvedColorScheme.primary.withAlpha(16),
+        ),
+        labelStyle: textTheme.labelLarge?.copyWith(
+          fontWeight: FontWeight.w600,
+        ),
+        unselectedLabelStyle: textTheme.labelLarge,
+      ),
+      inputDecorationTheme: InputDecorationThemeData(
+        filled: true,
+        fillColor: semantic.secondarySurface,
+        contentPadding: const EdgeInsets.symmetric(
+          horizontal: AppDesignTokens.space12,
+          vertical: AppDesignTokens.space12,
+        ),
+        hintStyle: textTheme.bodyMedium?.copyWith(
+          color: semantic.textTertiary,
+        ),
+        labelStyle: textTheme.bodyMedium?.copyWith(
+          color: semantic.textSecondary,
+        ),
+        border: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(AppDesignTokens.radius10),
+          borderSide: BorderSide(color: semantic.border),
+        ),
+        enabledBorder: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(AppDesignTokens.radius10),
+          borderSide: BorderSide(color: semantic.border),
+        ),
+        focusedBorder: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(AppDesignTokens.radius10),
+          borderSide: BorderSide(
+            color: resolvedColorScheme.primary,
+            width: 1.5,
+          ),
+        ),
+        errorBorder: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(AppDesignTokens.radius10),
+          borderSide: BorderSide(color: resolvedColorScheme.error),
+        ),
+        focusedErrorBorder: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(AppDesignTokens.radius10),
+          borderSide: BorderSide(
+            color: resolvedColorScheme.error,
+            width: 1.5,
+          ),
+        ),
+      ),
+      elevatedButtonTheme: ElevatedButtonThemeData(
+        style: ElevatedButton.styleFrom(
+          backgroundColor: resolvedColorScheme.primary,
+          foregroundColor: resolvedColorScheme.onPrimary,
+          disabledBackgroundColor: semantic.secondarySurface,
+          disabledForegroundColor: semantic.textDisabled,
+          shadowColor: Colors.transparent,
+          elevation: 0,
+          padding: const EdgeInsets.symmetric(
+            horizontal: AppDesignTokens.space16,
+            vertical: AppDesignTokens.space12,
+          ),
+          shape: controlShape,
+          textStyle: textTheme.labelLarge?.copyWith(
+            fontWeight: FontWeight.w600,
+          ),
+        ),
+      ),
+      filledButtonTheme: FilledButtonThemeData(
+        style: FilledButton.styleFrom(
+          padding: const EdgeInsets.symmetric(
+            horizontal: AppDesignTokens.space16,
+            vertical: AppDesignTokens.space12,
+          ),
+          shape: controlShape,
+          textStyle: textTheme.labelLarge?.copyWith(
+            fontWeight: FontWeight.w600,
+          ),
+        ),
+      ),
+      outlinedButtonTheme: OutlinedButtonThemeData(
+        style: OutlinedButton.styleFrom(
+          foregroundColor: semantic.textPrimary,
+          disabledForegroundColor: semantic.textDisabled,
+          side: BorderSide(color: semantic.border),
+          padding: const EdgeInsets.symmetric(
+            horizontal: AppDesignTokens.space16,
+            vertical: AppDesignTokens.space12,
+          ),
+          shape: borderedControlShape,
+          textStyle: textTheme.labelLarge?.copyWith(
+            fontWeight: FontWeight.w600,
+          ),
+        ),
+      ),
+      textButtonTheme: TextButtonThemeData(
+        style: TextButton.styleFrom(
+          foregroundColor: resolvedColorScheme.primary,
+          disabledForegroundColor: semantic.textDisabled,
+          padding: const EdgeInsets.symmetric(
+            horizontal: AppDesignTokens.space12,
+            vertical: AppDesignTokens.space8,
+          ),
+          shape: controlShape,
+          textStyle: textTheme.labelLarge?.copyWith(
+            fontWeight: FontWeight.w600,
+          ),
+        ),
+      ),
+      iconButtonTheme: IconButtonThemeData(
+        style: IconButton.styleFrom(
+          foregroundColor: semantic.textSecondary,
+          disabledForegroundColor: semantic.textDisabled,
+          highlightColor: resolvedColorScheme.primary.withAlpha(20),
+          shape: controlShape,
+        ),
+      ),
+      floatingActionButtonTheme: FloatingActionButtonThemeData(
+        backgroundColor: resolvedColorScheme.primary,
+        foregroundColor: resolvedColorScheme.onPrimary,
+        hoverColor: resolvedColorScheme.primaryContainer,
+        focusColor: resolvedColorScheme.primaryContainer,
+        elevation: 2,
+        focusElevation: 2,
+        hoverElevation: 3,
+        highlightElevation: 2,
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(AppDesignTokens.radius16),
+        ),
+      ),
+      chipTheme: ChipThemeData(
+        backgroundColor: semantic.secondarySurface,
+        selectedColor: resolvedColorScheme.primaryContainer,
+        disabledColor: semantic.secondarySurface,
+        side: BorderSide(color: semantic.border),
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(AppDesignTokens.radius8),
+        ),
+        labelStyle: textTheme.labelMedium,
+        secondaryLabelStyle: textTheme.labelMedium?.copyWith(
+          color: resolvedColorScheme.onPrimaryContainer,
+        ),
+        padding: const EdgeInsets.symmetric(
+          horizontal: AppDesignTokens.space8,
+          vertical: AppDesignTokens.space4,
+        ),
+      ),
+      popupMenuTheme: PopupMenuThemeData(
+        color: semantic.elevatedSurface,
+        surfaceTintColor: Colors.transparent,
+        shadowColor: semantic.shadow,
+        elevation: 4,
+        textStyle: textTheme.bodyMedium,
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(AppDesignTokens.radius10),
+          side: BorderSide(color: semantic.border),
+        ),
+      ),
+      snackBarTheme: SnackBarThemeData(
+        backgroundColor: isDark
+            ? semantic.secondarySurface
+            : AppDesignTokens.darkSecondary,
+        contentTextStyle: textTheme.bodyMedium?.copyWith(
+          color: AppDesignTokens.darkTextPrimary,
+        ),
+        actionTextColor: isDark
+            ? resolvedColorScheme.primary
+            : resolvedColorScheme.primaryContainer,
+        elevation: 0,
+        behavior: SnackBarBehavior.floating,
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(AppDesignTokens.radius10),
+        ),
+      ),
+      tooltipTheme: TooltipThemeData(
+        decoration: BoxDecoration(
+          color: isDark
+              ? AppDesignTokens.lightSecondary
+              : AppDesignTokens.darkSecondary,
+          borderRadius: BorderRadius.circular(AppDesignTokens.radius6),
+        ),
+        textStyle: textTheme.bodySmall?.copyWith(
+          color: isDark
+              ? AppDesignTokens.lightTextPrimary
+              : AppDesignTokens.darkTextPrimary,
+        ),
+      ),
+      checkboxTheme: CheckboxThemeData(
+        fillColor: WidgetStateProperty.resolveWith((states) {
+          if (states.contains(WidgetState.disabled)) {
+            return states.contains(WidgetState.selected)
+                ? resolvedColorScheme.primary.withAlpha(96)
+                : Colors.transparent;
+          }
+          if (states.contains(WidgetState.selected)) {
+            return resolvedColorScheme.primary;
+          }
+          return Colors.transparent;
+        }),
+        checkColor: WidgetStateProperty.resolveWith((states) {
+          return states.contains(WidgetState.disabled)
+              ? resolvedColorScheme.onSurface.withAlpha(96)
+              : resolvedColorScheme.onPrimary;
+        }),
+        side: WidgetStateBorderSide.resolveWith((states) {
+          return BorderSide(
+            color: states.contains(WidgetState.disabled)
+                ? semantic.textDisabled
+                : semantic.textTertiary,
+            width: 1.5,
+          );
+        }),
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(AppDesignTokens.radius6),
+        ),
+      ),
+      radioTheme: RadioThemeData(
+        fillColor: WidgetStateProperty.resolveWith((states) {
+          if (states.contains(WidgetState.disabled)) {
+            return semantic.textDisabled;
+          }
+          return states.contains(WidgetState.selected)
+              ? resolvedColorScheme.primary
+              : semantic.textTertiary;
+        }),
+      ),
+      switchTheme: SwitchThemeData(
+        thumbColor: WidgetStateProperty.resolveWith((states) {
+          if (states.contains(WidgetState.disabled)) {
+            return semantic.textDisabled;
+          }
+          return states.contains(WidgetState.selected)
+              ? resolvedColorScheme.onPrimary
+              : semantic.textTertiary;
+        }),
+        trackColor: WidgetStateProperty.resolveWith((states) {
+          if (states.contains(WidgetState.disabled)) {
+            return semantic.secondarySurface;
+          }
+          return states.contains(WidgetState.selected)
+              ? resolvedColorScheme.primary
+              : semantic.secondarySurface;
+        }),
+        trackOutlineColor: WidgetStateProperty.resolveWith((states) {
+          if (states.contains(WidgetState.disabled)) {
+            return semantic.border;
+          }
+          return states.contains(WidgetState.selected)
+              ? Colors.transparent
+              : semantic.border;
+        }),
+      ),
+      progressIndicatorTheme: ProgressIndicatorThemeData(
+        color: resolvedColorScheme.primary,
+        linearTrackColor: semantic.secondarySurface,
+        circularTrackColor: semantic.secondarySurface,
+      ),
+      scrollbarTheme: ScrollbarThemeData(
+        thumbColor: WidgetStatePropertyAll(semantic.textTertiary),
+        trackColor: const WidgetStatePropertyAll(Colors.transparent),
+        radius: const Radius.circular(AppDesignTokens.radius8),
+        thickness: const WidgetStatePropertyAll(5.0),
       ),
     );
   }
 
-  static ThemeData darkTheme({String? fontFamily}) {
-    return ThemeData.dark().copyWith(
-      colorScheme: AppColors.darkColorScheme,
-      visualDensity: VisualDensity.standard,
-      textTheme: ThemeData.dark().textTheme.apply(
-            fontFamily: fontFamily,
-          ),
-      primaryTextTheme: ThemeData().textTheme.apply(
-            fontFamily: fontFamily,
-          ),
-      appBarTheme: AppBarTheme(
-        //elevation: 0,
-
-        centerTitle: true,
-        titleTextStyle: TextStyle(
+  static TextTheme _buildTextTheme({
+    required Brightness brightness,
+    required String? fontFamily,
+    required AppThemeExtension semantic,
+  }) {
+    final baseTextTheme = ThemeData(
+      brightness: brightness,
+      useMaterial3: true,
+    ).textTheme.apply(
           fontFamily: fontFamily,
-          fontSize: 16,
-          color: Colors.white,
-        ),
-        foregroundColor: Colors.white,
-        systemOverlayStyle: SystemUiOverlayStyle.light.copyWith(
-          systemNavigationBarColor: Colors.transparent,
-        ),
+          bodyColor: semantic.textPrimary,
+          displayColor: semantic.textPrimary,
+        );
+
+    return baseTextTheme.copyWith(
+      displayLarge: baseTextTheme.displayLarge?.copyWith(
+        fontWeight: FontWeight.w700,
+        letterSpacing: -1.2,
       ),
-      // radioTheme: RadioThemeData(
-      //   fillColor: MaterialStateProperty.all(AppColors.darkColorScheme.primary),
-      // ),
-      // checkboxTheme: CheckboxThemeData(
-      //   fillColor: MaterialStateProperty.all(AppColors.darkColorScheme.primary),
-      // ),
-      // tabBarTheme: TabBarTheme(
-      //   labelColor: AppColors.darkColorScheme.primary,
-      //   unselectedLabelColor: Colors.white70,
-      //   indicator: RectangularIndicator(
-      //     color: Colors.white.withAlpha(50),
-      //     topLeftRadius: 24,
-      //     bottomLeftRadius: 24,
-      //     topRightRadius: 24,
-      //     bottomRightRadius: 24,
-      //     verticalPadding: 8,
-      //     horizontalPadding: 0,
-      //   ),
-      // ),
+      displayMedium: baseTextTheme.displayMedium?.copyWith(
+        fontWeight: FontWeight.w700,
+        letterSpacing: -0.8,
+      ),
+      displaySmall: baseTextTheme.displaySmall?.copyWith(
+        fontWeight: FontWeight.w700,
+        letterSpacing: -0.4,
+      ),
+      headlineLarge: baseTextTheme.headlineLarge?.copyWith(
+        fontWeight: FontWeight.w700,
+        letterSpacing: -0.3,
+      ),
+      headlineMedium: baseTextTheme.headlineMedium?.copyWith(
+        fontWeight: FontWeight.w700,
+        letterSpacing: -0.2,
+      ),
+      headlineSmall: baseTextTheme.headlineSmall?.copyWith(
+        fontWeight: FontWeight.w600,
+      ),
+      titleLarge: baseTextTheme.titleLarge?.copyWith(
+        fontWeight: FontWeight.w700,
+      ),
+      titleMedium: baseTextTheme.titleMedium?.copyWith(
+        fontWeight: FontWeight.w600,
+      ),
+      titleSmall: baseTextTheme.titleSmall?.copyWith(
+        color: semantic.textSecondary,
+        fontWeight: FontWeight.w600,
+      ),
+      bodyLarge: baseTextTheme.bodyLarge?.copyWith(
+        color: semantic.textPrimary,
+        height: 1.45,
+      ),
+      bodyMedium: baseTextTheme.bodyMedium?.copyWith(
+        color: semantic.textPrimary,
+        height: 1.45,
+      ),
+      bodySmall: baseTextTheme.bodySmall?.copyWith(
+        color: semantic.textSecondary,
+        height: 1.4,
+      ),
+      labelLarge: baseTextTheme.labelLarge?.copyWith(
+        color: semantic.textPrimary,
+        fontWeight: FontWeight.w600,
+      ),
+      labelMedium: baseTextTheme.labelMedium?.copyWith(
+        color: semantic.textSecondary,
+        fontWeight: FontWeight.w500,
+      ),
+      labelSmall: baseTextTheme.labelSmall?.copyWith(
+        color: semantic.textTertiary,
+        fontWeight: FontWeight.w500,
+      ),
     );
   }
 
-  static const vGap4 = SizedBox(
-    height: 4,
-  );
-  static const vGap8 = SizedBox(
-    height: 8,
-  );
-  static const vGap12 = SizedBox(
-    height: 12,
-  );
-  static const vGap24 = SizedBox(
-    height: 24,
-  );
-  static const vGap32 = SizedBox(
-    height: 32,
-  );
-  static const vGap48 = SizedBox(
-    height: 48,
-  );
+  static const vGap4 = SizedBox(height: 4);
+  static const vGap8 = SizedBox(height: 8);
+  static const vGap12 = SizedBox(height: 12);
+  static const vGap24 = SizedBox(height: 24);
+  static const vGap32 = SizedBox(height: 32);
+  static const vGap48 = SizedBox(height: 48);
 
-  static const hGap4 = SizedBox(
-    width: 4,
-  );
-  static const hGap8 = SizedBox(
-    width: 8,
-  );
-  static const hGap12 = SizedBox(
-    width: 12,
-  );
-  static const hGap16 = SizedBox(
-    width: 16,
-  );
-
-  static const hGap24 = SizedBox(
-    width: 24,
-  );
-  static const hGap32 = SizedBox(
-    width: 32,
-  );
-  static const hGap48 = SizedBox(
-    width: 48,
-  );
+  static const hGap4 = SizedBox(width: 4);
+  static const hGap8 = SizedBox(width: 8);
+  static const hGap12 = SizedBox(width: 12);
+  static const hGap16 = SizedBox(width: 16);
+  static const hGap24 = SizedBox(width: 24);
+  static const hGap32 = SizedBox(width: 32);
+  static const hGap48 = SizedBox(width: 48);
 
   static const edgeInsetsH4 = EdgeInsets.symmetric(horizontal: 4);
   static const edgeInsetsH8 = EdgeInsets.symmetric(horizontal: 8);
@@ -170,12 +615,15 @@ class AppStyle {
   static const edgeInsetsB12 = EdgeInsets.only(bottom: 12);
   static const edgeInsetsB24 = EdgeInsets.only(bottom: 24);
 
-  static BorderRadius radius4 = BorderRadius.circular(4);
-  static BorderRadius radius8 = BorderRadius.circular(8);
-  static BorderRadius radius12 = BorderRadius.circular(12);
-  static BorderRadius radius24 = BorderRadius.circular(24);
-  static BorderRadius radius32 = BorderRadius.circular(32);
-  static BorderRadius radius48 = BorderRadius.circular(48);
+  static final BorderRadius radius4 = BorderRadius.circular(4);
+  static final BorderRadius radius6 = BorderRadius.circular(6);
+  static final BorderRadius radius8 = BorderRadius.circular(8);
+  static final BorderRadius radius10 = BorderRadius.circular(10);
+  static final BorderRadius radius12 = BorderRadius.circular(12);
+  static final BorderRadius radius16 = BorderRadius.circular(16);
+  static final BorderRadius radius24 = BorderRadius.circular(24);
+  static final BorderRadius radius32 = BorderRadius.circular(32);
+  static final BorderRadius radius48 = BorderRadius.circular(48);
 
   /// 顶部状态栏的高度
   static double get statusBarHeight => MediaQuery.of(Get.context!).padding.top;
@@ -184,11 +632,16 @@ class AppStyle {
   static double get bottomBarHeight =>
       MediaQuery.of(Get.context!).padding.bottom;
 
-  static Divider get divider => Divider(
-        height: 1,
-        thickness: 1,
-        indent: 16,
-        endIndent: 16,
-        color: Colors.grey.withAlpha(25),
-      );
+  static Divider get divider {
+    final context = Get.context;
+    return Divider(
+      height: 1,
+      thickness: 1,
+      indent: 16,
+      endIndent: 16,
+      color: context == null
+          ? AppDesignTokens.lightDivider
+          : Theme.of(context).dividerColor,
+    );
+  }
 }

--- a/simple_live_app/lib/app/design_system/app_design_tokens.dart
+++ b/simple_live_app/lib/app/design_system/app_design_tokens.dart
@@ -1,0 +1,49 @@
+import 'package:flutter/material.dart';
+
+abstract final class AppDesignTokens {
+  static const int defaultSeedValue = 0xFF335EEA;
+  static const Color defaultSeedColor = Color(defaultSeedValue);
+
+  static const Color lightBody = Color(0xFFFFFFFF);
+  static const Color lightSecondary = Color(0xFFF5F5F7);
+  static const Color darkBody = Color(0xFF222222);
+  static const Color darkSecondary = Color(0xFF323232);
+
+  static const Color lightTextPrimary = Color(0xE0000000);
+  static const Color lightTextSecondary = Color(0xAD000000);
+  static const Color lightTextTertiary = Color(0x8A000000);
+  static const Color lightTextDisabled = Color(0x61000000);
+  static const Color darkTextPrimary = Color(0xE0FFFFFF);
+  static const Color darkTextSecondary = Color(0xADFFFFFF);
+  static const Color darkTextTertiary = Color(0x8AFFFFFF);
+  static const Color darkTextDisabled = Color(0x61FFFFFF);
+
+  static const Color lightBorder = Color(0x14000000);
+  static const Color lightDivider = Color(0x0F000000);
+  static const Color lightShadow = Color(0x14000000);
+  static const Color darkBorder = Color(0x1FFFFFFF);
+  static const Color darkDivider = Color(0x14FFFFFF);
+  static const Color darkShadow = Color(0x52000000);
+
+  static const double radius6 = 6;
+  static const double radius8 = 8;
+  static const double radius10 = 10;
+  static const double radius12 = 12;
+  static const double radius16 = 16;
+
+  static const double space4 = 4;
+  static const double space8 = 8;
+  static const double space12 = 12;
+  static const double space16 = 16;
+  static const double space24 = 24;
+}
+
+abstract final class AppTypography {
+  // Reserved for a properly licensed bundled family. A user-selected custom
+  // family must continue to take precedence when one is configured.
+  static const String? bundledDefaultFontFamily = null;
+
+  static String? resolveFontFamily(String? customFontFamily) {
+    return customFontFamily ?? bundledDefaultFontFamily;
+  }
+}

--- a/simple_live_app/lib/app/design_system/app_theme_extension.dart
+++ b/simple_live_app/lib/app/design_system/app_theme_extension.dart
@@ -1,0 +1,115 @@
+import 'package:flutter/material.dart';
+import 'package:simple_live_app/app/design_system/app_design_tokens.dart';
+
+@immutable
+class AppThemeExtension extends ThemeExtension<AppThemeExtension> {
+  const AppThemeExtension({
+    required this.body,
+    required this.secondarySurface,
+    required this.elevatedSurface,
+    required this.textPrimary,
+    required this.textSecondary,
+    required this.textTertiary,
+    required this.textDisabled,
+    required this.border,
+    required this.divider,
+    required this.shadow,
+  });
+
+  factory AppThemeExtension.light() {
+    return const AppThemeExtension(
+      body: AppDesignTokens.lightBody,
+      secondarySurface: AppDesignTokens.lightSecondary,
+      elevatedSurface: Colors.white,
+      textPrimary: AppDesignTokens.lightTextPrimary,
+      textSecondary: AppDesignTokens.lightTextSecondary,
+      textTertiary: AppDesignTokens.lightTextTertiary,
+      textDisabled: AppDesignTokens.lightTextDisabled,
+      border: AppDesignTokens.lightBorder,
+      divider: AppDesignTokens.lightDivider,
+      shadow: AppDesignTokens.lightShadow,
+    );
+  }
+
+  factory AppThemeExtension.dark() {
+    return const AppThemeExtension(
+      body: AppDesignTokens.darkBody,
+      secondarySurface: AppDesignTokens.darkSecondary,
+      elevatedSurface: Color(0xFF2A2A2A),
+      textPrimary: AppDesignTokens.darkTextPrimary,
+      textSecondary: AppDesignTokens.darkTextSecondary,
+      textTertiary: AppDesignTokens.darkTextTertiary,
+      textDisabled: AppDesignTokens.darkTextDisabled,
+      border: AppDesignTokens.darkBorder,
+      divider: AppDesignTokens.darkDivider,
+      shadow: AppDesignTokens.darkShadow,
+    );
+  }
+
+  final Color body;
+  final Color secondarySurface;
+  final Color elevatedSurface;
+  final Color textPrimary;
+  final Color textSecondary;
+  final Color textTertiary;
+  final Color textDisabled;
+  final Color border;
+  final Color divider;
+  final Color shadow;
+
+  @override
+  AppThemeExtension copyWith({
+    Color? body,
+    Color? secondarySurface,
+    Color? elevatedSurface,
+    Color? textPrimary,
+    Color? textSecondary,
+    Color? textTertiary,
+    Color? textDisabled,
+    Color? border,
+    Color? divider,
+    Color? shadow,
+  }) {
+    return AppThemeExtension(
+      body: body ?? this.body,
+      secondarySurface: secondarySurface ?? this.secondarySurface,
+      elevatedSurface: elevatedSurface ?? this.elevatedSurface,
+      textPrimary: textPrimary ?? this.textPrimary,
+      textSecondary: textSecondary ?? this.textSecondary,
+      textTertiary: textTertiary ?? this.textTertiary,
+      textDisabled: textDisabled ?? this.textDisabled,
+      border: border ?? this.border,
+      divider: divider ?? this.divider,
+      shadow: shadow ?? this.shadow,
+    );
+  }
+
+  @override
+  AppThemeExtension lerp(
+    covariant AppThemeExtension? other,
+    double t,
+  ) {
+    if (other == null) {
+      return this;
+    }
+    return AppThemeExtension(
+      body: Color.lerp(body, other.body, t)!,
+      secondarySurface:
+          Color.lerp(secondarySurface, other.secondarySurface, t)!,
+      elevatedSurface: Color.lerp(elevatedSurface, other.elevatedSurface, t)!,
+      textPrimary: Color.lerp(textPrimary, other.textPrimary, t)!,
+      textSecondary: Color.lerp(textSecondary, other.textSecondary, t)!,
+      textTertiary: Color.lerp(textTertiary, other.textTertiary, t)!,
+      textDisabled: Color.lerp(textDisabled, other.textDisabled, t)!,
+      border: Color.lerp(border, other.border, t)!,
+      divider: Color.lerp(divider, other.divider, t)!,
+      shadow: Color.lerp(shadow, other.shadow, t)!,
+    );
+  }
+}
+
+extension AppThemeContext on BuildContext {
+  AppThemeExtension get appTheme {
+    return Theme.of(this).extension<AppThemeExtension>()!;
+  }
+}

--- a/simple_live_app/lib/main.dart
+++ b/simple_live_app/lib/main.dart
@@ -154,8 +154,8 @@ class MyApp extends StatelessWidget {
         Color(AppStyleSettingController.instance.styleColor.value);
     return DynamicColorBuilder(
         builder: ((ColorScheme? lightDynamic, ColorScheme? darkDynamic) {
-      ColorScheme? lightColorScheme;
-      ColorScheme? darkColorScheme;
+      final ColorScheme lightColorScheme;
+      final ColorScheme darkColorScheme;
       if (lightDynamic != null && darkDynamic != null && isDynamicColor) {
         lightColorScheme = lightDynamic;
         darkColorScheme = darkDynamic;
@@ -165,17 +165,21 @@ class MyApp extends StatelessWidget {
           brightness: Brightness.light,
         );
         darkColorScheme = ColorScheme.fromSeed(
-            seedColor: styleColor, brightness: Brightness.dark);
+          seedColor: styleColor,
+          brightness: Brightness.dark,
+        );
       }
       return Obx(
         () => GetMaterialApp(
           title: "Slive",
           theme: AppStyle.light(
+            colorScheme: lightColorScheme,
             fontFamily: AppStyleSettingController.instance.curFontName.value,
-          ).copyWith(colorScheme: lightColorScheme),
+          ),
           darkTheme: AppStyle.darkTheme(
+            colorScheme: darkColorScheme,
             fontFamily: AppStyleSettingController.instance.curFontName.value,
-          ).copyWith(colorScheme: darkColorScheme),
+          ),
           themeMode: ThemeMode
               .values[Get.find<AppSettingsController>().themeMode.value],
           initialRoute: RoutePath.kIndex,

--- a/simple_live_app/lib/modules/category/category_list_view.dart
+++ b/simple_live_app/lib/modules/category/category_list_view.dart
@@ -1,120 +1,236 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_easyrefresh/easy_refresh.dart';
-
 import 'package:get/get.dart';
-import 'package:simple_live_app/app/app_style.dart';
+import 'package:simple_live_app/app/design_system/app_design_tokens.dart';
+import 'package:simple_live_app/app/design_system/app_theme_extension.dart';
 import 'package:simple_live_app/modules/category/category_list_controller.dart';
 import 'package:simple_live_app/routes/app_navigation.dart';
 import 'package:simple_live_app/widgets/keep_alive_wrapper.dart';
 import 'package:simple_live_app/widgets/net_image.dart';
-import 'package:simple_live_app/widgets/shadow_card.dart';
 import 'package:simple_live_core/simple_live_core.dart';
 import 'package:sticky_headers/sticky_headers.dart';
 
 class CategoryListView extends StatelessWidget {
   final String tag;
   const CategoryListView(this.tag, {super.key});
+
   CategoryListController get controller =>
       Get.find<CategoryListController>(tag: tag);
+
   @override
   Widget build(BuildContext context) {
     return KeepAliveWrapper(
-      child: Obx(
-        () => EasyRefresh(
-          firstRefresh: true,
-          controller: controller.easyRefreshController,
-          onRefresh: controller.refreshData,
-          header: MaterialHeader(
-            completeDuration: const Duration(milliseconds: 400),
-          ),
-          child: ListView.builder(
-            padding: AppStyle.edgeInsetsA12,
-            itemCount: controller.list.length,
-            controller: controller.scrollController,
-            itemBuilder: (_, i) {
-              var item = controller.list[i];
-              return Column(
-                children: [
-                  StickyHeader(
-                    header: Container(
-                      padding: AppStyle.edgeInsetsV8.copyWith(left: 4),
-                      color: Theme.of(context).scaffoldBackgroundColor,
-                      alignment: Alignment.centerLeft,
-                      child: Text(
-                        item.name,
-                        style: const TextStyle(
-                            fontSize: 18, fontWeight: FontWeight.bold),
-                      ),
-                    ),
-                    content: Obx(
-                      () => GridView.count(
-                        shrinkWrap: true,
-                        padding: AppStyle.edgeInsetsV8,
-                        physics: const NeverScrollableScrollPhysics(),
-                        crossAxisCount: MediaQuery.of(context).size.width ~/ 80,
-                        crossAxisSpacing: 8,
-                        mainAxisSpacing: 8,
-                        children: item.showAll.value
-                            ? (item.children
-                                .map(
-                                  (e) => buildSubCategory(e),
-                                )
-                                .toList())
-                            : (item.take15
-                                .map(
-                                  (e) => buildSubCategory(e),
-                                )
-                                .toList()
-                              ..add(buildShowMore(item))),
-                      ),
-                    ),
+      child: LayoutBuilder(
+        builder: (context, constraints) {
+          const targetCellWidth = 104.0;
+          const spacing = AppDesignTokens.space8;
+          const maxColumnCount = 10;
+          final semantic = context.appTheme;
+          final gutter = _contentGutter(constraints.maxWidth);
+          final maxViewportWidth = (targetCellWidth * maxColumnCount) +
+              (spacing * (maxColumnCount - 1)) +
+              (gutter * 2);
+          final viewportWidth = constraints.maxWidth > maxViewportWidth
+              ? maxViewportWidth
+              : constraints.maxWidth;
+          final availableWidth = viewportWidth - (gutter * 2);
+          var columnCount =
+              ((availableWidth + spacing) / (targetCellWidth + spacing))
+                  .floor();
+          if (columnCount < 1) columnCount = 1;
+          if (columnCount > maxColumnCount) columnCount = maxColumnCount;
+
+          return Align(
+            alignment: Alignment.topCenter,
+            child: SizedBox(
+              width: viewportWidth,
+              child: Obx(
+                () => EasyRefresh(
+                  firstRefresh: true,
+                  controller: controller.easyRefreshController,
+                  onRefresh: controller.refreshData,
+                  header: MaterialHeader(
+                    completeDuration: const Duration(milliseconds: 400),
                   ),
-                ],
-              );
-            },
+                  child: ListView.builder(
+                    padding: EdgeInsets.fromLTRB(gutter, 8, gutter, 24),
+                    itemCount: controller.list.length,
+                    controller: controller.scrollController,
+                    itemBuilder: (_, i) {
+                      final item = controller.list[i];
+                      return StickyHeader(
+                        header: Container(
+                          width: double.infinity,
+                          padding: const EdgeInsets.fromLTRB(4, 14, 4, 10),
+                          decoration: BoxDecoration(
+                            color: semantic.body,
+                            border: Border(
+                              bottom: BorderSide(color: semantic.divider),
+                            ),
+                          ),
+                          child: Text(
+                            item.name,
+                            maxLines: 1,
+                            overflow: TextOverflow.ellipsis,
+                            style:
+                                Theme.of(context).textTheme.titleLarge?.copyWith(
+                                      color: semantic.textPrimary,
+                                      fontWeight: FontWeight.w700,
+                                    ),
+                          ),
+                        ),
+                        content: Obx(
+                          () {
+                            final showAll = item.showAll.value;
+                            final children =
+                                showAll ? item.children : item.take15;
+                            final itemCount =
+                                children.length + (showAll ? 0 : 1);
+
+                            return GridView.builder(
+                              shrinkWrap: true,
+                              padding:
+                                  const EdgeInsets.only(top: 12, bottom: 24),
+                              physics: const NeverScrollableScrollPhysics(),
+                              itemCount: itemCount,
+                              gridDelegate:
+                                  SliverGridDelegateWithFixedCrossAxisCount(
+                                crossAxisCount: columnCount,
+                                crossAxisSpacing: spacing,
+                                mainAxisSpacing: spacing,
+                                mainAxisExtent: 96,
+                              ),
+                              itemBuilder: (context, index) {
+                                if (index == children.length) {
+                                  return _ShowAllCategoryCell(
+                                    onTap: () => item.showAll.value = true,
+                                  );
+                                }
+                                return _SubCategoryCell(
+                                  item: children[index],
+                                  onTap: () {
+                                    AppNavigator.toCategoryDetail(
+                                      site: controller.site,
+                                      category: children[index],
+                                    );
+                                  },
+                                );
+                              },
+                            );
+                          },
+                        ),
+                      );
+                    },
+                  ),
+                ),
+              ),
+            ),
+          );
+        },
+      ),
+    );
+  }
+
+  double _contentGutter(double width) {
+    if (width >= 1200) return 32;
+    if (width >= 720) return 24;
+    return 12;
+  }
+}
+
+class _SubCategoryCell extends StatelessWidget {
+  const _SubCategoryCell({
+    required this.item,
+    required this.onTap,
+  });
+
+  final LiveSubCategory item;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final semantic = context.appTheme;
+    final radius = BorderRadius.circular(AppDesignTokens.radius10);
+
+    return Material(
+      color: semantic.secondarySurface,
+      shape: RoundedRectangleBorder(
+        borderRadius: radius,
+        side: BorderSide(color: semantic.border),
+      ),
+      clipBehavior: Clip.antiAlias,
+      child: InkWell(
+        onTap: onTap,
+        borderRadius: radius,
+        child: Padding(
+          padding: const EdgeInsets.all(AppDesignTokens.space8),
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              NetImage(
+                item.pic ?? '',
+                width: 40,
+                height: 40,
+                borderRadius: AppDesignTokens.radius8,
+              ),
+              const SizedBox(height: AppDesignTokens.space8),
+              Text(
+                item.name,
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+                textAlign: TextAlign.center,
+                style: Theme.of(context).textTheme.labelMedium?.copyWith(
+                      color: semantic.textPrimary,
+                      fontWeight: FontWeight.w600,
+                    ),
+              ),
+            ],
           ),
         ),
       ),
     );
   }
+}
 
-  Widget buildSubCategory(LiveSubCategory item) {
-    return ShadowCard(
-      onTap: () {
-        AppNavigator.toCategoryDetail(site: controller.site, category: item);
-      },
-      child: Column(
-        mainAxisAlignment: MainAxisAlignment.center,
-        children: [
-          NetImage(
-            item.pic ?? "",
-            width: 40,
-            height: 40,
-            borderRadius: 8,
-          ),
-          AppStyle.vGap4,
-          Text(
-            item.name,
-            maxLines: 1,
-            textAlign: TextAlign.center,
-            style: const TextStyle(fontSize: 12),
-          ),
-        ],
+class _ShowAllCategoryCell extends StatelessWidget {
+  const _ShowAllCategoryCell({required this.onTap});
+
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final semantic = context.appTheme;
+    final theme = Theme.of(context);
+    final radius = BorderRadius.circular(AppDesignTokens.radius10);
+
+    return Material(
+      color: semantic.secondarySurface,
+      shape: RoundedRectangleBorder(
+        borderRadius: radius,
+        side: BorderSide(color: semantic.border),
       ),
-    );
-  }
-
-  Widget buildShowMore(AppLiveCategory item) {
-    return ShadowCard(
-      onTap: () {
-        item.showAll.value = true;
-      },
-      child: const Center(
-        child: Text(
-          "显示全部",
-          maxLines: 1,
-          textAlign: TextAlign.center,
-          style: TextStyle(fontSize: 12),
+      clipBehavior: Clip.antiAlias,
+      child: InkWell(
+        onTap: onTap,
+        borderRadius: radius,
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Icon(
+              Icons.keyboard_arrow_down_rounded,
+              color: theme.colorScheme.primary,
+            ),
+            const SizedBox(height: AppDesignTokens.space4),
+            Text(
+              '显示全部',
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+              style: theme.textTheme.labelMedium?.copyWith(
+                color: theme.colorScheme.primary,
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+          ],
         ),
       ),
     );

--- a/simple_live_app/lib/modules/category/category_page.dart
+++ b/simple_live_app/lib/modules/category/category_page.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
-import 'package:simple_live_app/app/app_style.dart';
+import 'package:simple_live_app/app/design_system/app_design_tokens.dart';
+import 'package:simple_live_app/app/design_system/app_theme_extension.dart';
 import 'package:simple_live_app/app/sites.dart';
 import 'package:simple_live_app/modules/category/category_controller.dart';
 import 'package:simple_live_app/modules/category/category_list_view.dart';
@@ -10,44 +11,98 @@ class CategoryPage extends GetView<CategoryController> {
 
   @override
   Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final semantic = context.appTheme;
+
     return Scaffold(
       appBar: AppBar(
-        titleSpacing: 8,
-        title: TabBar(
-          controller: controller.tabController,
-          padding: EdgeInsets.zero,
-          tabAlignment: TabAlignment.center,
-          tabs: Sites.supportSites
-              .map(
-                (e) => Tab(
-                  //text: e.name,
-                  child: Row(
-                    children: [
-                      Image.asset(
-                        e.logo,
-                        width: 24,
-                      ),
-                      AppStyle.hGap8,
-                      Text(e.name),
-                    ],
-                  ),
+        centerTitle: false,
+        titleSpacing: AppDesignTokens.space24,
+        toolbarHeight: 68,
+        title: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Text(
+              '直播分类',
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+              style: theme.textTheme.headlineSmall?.copyWith(
+                color: semantic.textPrimary,
+                fontWeight: FontWeight.w700,
+              ),
+            ),
+            Text(
+              '按频道浏览',
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+              style: theme.textTheme.labelMedium?.copyWith(
+                color: semantic.textTertiary,
+              ),
+            ),
+          ],
+        ),
+        bottom: PreferredSize(
+          preferredSize: const Size.fromHeight(48),
+          child: DecoratedBox(
+            decoration: BoxDecoration(
+              border: Border(
+                bottom: BorderSide(color: semantic.border),
+              ),
+            ),
+            child: SizedBox(
+              width: double.infinity,
+              height: 48,
+              child: TabBar(
+                controller: controller.tabController,
+                isScrollable: true,
+                tabAlignment: TabAlignment.start,
+                indicatorSize: TabBarIndicatorSize.label,
+                labelPadding: const EdgeInsets.symmetric(
+                  horizontal: AppDesignTokens.space12,
                 ),
-              )
-              .toList(),
-          labelPadding: AppStyle.edgeInsetsH20,
-          isScrollable: true,
-          indicatorSize: TabBarIndicatorSize.label,
+                tabs: Sites.supportSites.map(_SiteTab.new).toList(),
+              ),
+            ),
+          ),
         ),
       ),
       body: TabBarView(
         controller: controller.tabController,
         children: Sites.supportSites
             .map(
-              (e) => CategoryListView(
-                e.id,
-              ),
+              (site) => CategoryListView(site.id),
             )
             .toList(),
+      ),
+    );
+  }
+}
+
+class _SiteTab extends StatelessWidget {
+  const _SiteTab(this.site);
+
+  final Site site;
+
+  @override
+  Widget build(BuildContext context) {
+    return Tab(
+      height: 40,
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Image.asset(
+            site.logo,
+            width: 20,
+            height: 20,
+          ),
+          const SizedBox(width: AppDesignTokens.space8),
+          Text(
+            site.name,
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
+          ),
+        ],
       ),
     );
   }

--- a/simple_live_app/lib/modules/category/detail/category_detail_page.dart
+++ b/simple_live_app/lib/modules/category/detail/category_detail_page.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
-
 import 'package:get/get.dart';
-import 'package:simple_live_app/app/app_style.dart';
+import 'package:simple_live_app/app/design_system/app_design_tokens.dart';
+import 'package:simple_live_app/app/design_system/app_theme_extension.dart';
 import 'package:simple_live_app/modules/category/detail/category_detail_controller.dart';
 import 'package:simple_live_app/widgets/keep_alive_wrapper.dart';
 import 'package:simple_live_app/widgets/live_room_card.dart';
@@ -12,28 +12,76 @@ class CategoryDetailPage extends GetView<CategoryDetailController> {
 
   @override
   Widget build(BuildContext context) {
-    var c = MediaQuery.of(context).size.width ~/ 200;
-    if (c < 2) {
-      c = 2;
-    }
+    final semantic = context.appTheme;
+
     return Scaffold(
       appBar: AppBar(
-        title: Text(controller.subCategory.name),
+        centerTitle: false,
+        title: Text(
+          controller.subCategory.name,
+          maxLines: 1,
+          overflow: TextOverflow.ellipsis,
+          style: Theme.of(context).textTheme.titleLarge?.copyWith(
+                color: semantic.textPrimary,
+                fontWeight: FontWeight.w700,
+              ),
+        ),
+        bottom: PreferredSize(
+          preferredSize: const Size.fromHeight(1),
+          child: Divider(
+            height: 1,
+            thickness: 1,
+            color: semantic.border,
+          ),
+        ),
       ),
       body: KeepAliveWrapper(
-        child: PageGridView(
-          pageController: controller,
-          padding: AppStyle.edgeInsetsA12,
-          firstRefresh: true,
-          mainAxisSpacing: 12,
-          crossAxisSpacing: 12,
-          crossAxisCount: c,
-          itemBuilder: (_, i) {
-            var item = controller.list[i];
-            return LiveRoomCard(controller.site, item);
+        child: LayoutBuilder(
+          builder: (context, constraints) {
+            const targetCardWidth = 280.0;
+            const spacing = AppDesignTokens.space16;
+            const maxColumnCount = 5;
+            final gutter = _contentGutter(constraints.maxWidth);
+            final maxViewportWidth = (targetCardWidth * maxColumnCount) +
+                (spacing * (maxColumnCount - 1)) +
+                (gutter * 2);
+            final viewportWidth = constraints.maxWidth > maxViewportWidth
+                ? maxViewportWidth
+                : constraints.maxWidth;
+            final availableWidth = viewportWidth - (gutter * 2);
+            var columnCount =
+                ((availableWidth + spacing) / (targetCardWidth + spacing))
+                    .floor();
+            if (columnCount < 1) columnCount = 1;
+            if (columnCount > maxColumnCount) columnCount = maxColumnCount;
+
+            return Align(
+              alignment: Alignment.topCenter,
+              child: SizedBox(
+                width: viewportWidth,
+                child: PageGridView(
+                  pageController: controller,
+                  padding: EdgeInsets.fromLTRB(gutter, 20, gutter, 24),
+                  firstRefresh: true,
+                  mainAxisSpacing: spacing,
+                  crossAxisSpacing: spacing,
+                  crossAxisCount: columnCount,
+                  itemBuilder: (_, i) {
+                    final item = controller.list[i];
+                    return LiveRoomCard(controller.site, item);
+                  },
+                ),
+              ),
+            );
           },
         ),
       ),
     );
+  }
+
+  double _contentGutter(double width) {
+    if (width >= 1200) return 32;
+    if (width >= 720) return 24;
+    return 12;
   }
 }

--- a/simple_live_app/lib/modules/follow_user/follow_app_setting/follow_app_settings_page.dart
+++ b/simple_live_app/lib/modules/follow_user/follow_app_setting/follow_app_settings_page.dart
@@ -1,7 +1,9 @@
-﻿import 'package:flutter/material.dart';
+import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import 'package:remixicon/remixicon.dart';
 import 'package:simple_live_app/app/app_style.dart';
+import 'package:simple_live_app/app/design_system/app_design_tokens.dart';
+import 'package:simple_live_app/app/design_system/app_theme_extension.dart';
 import 'package:simple_live_app/models/db/follow_user.dart';
 import 'package:simple_live_app/modules/follow_user/follow_app_setting/follow_app_settings_controller.dart';
 import 'package:simple_live_app/services/follow_service.dart';
@@ -17,74 +19,34 @@ class FollowSettingsPage extends GetView<FollowAppSettingsController> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(
-        title: const Text("关注设置"),
-      ),
-      body: ListView(
-        padding: AppStyle.edgeInsetsA12,
-        children: [
-          Column(
-            mainAxisSize: MainAxisSize.min,
-            crossAxisAlignment: CrossAxisAlignment.stretch,
+      appBar: AppBar(title: const Text('关注设置')),
+      body: Align(
+        alignment: Alignment.topCenter,
+        child: ConstrainedBox(
+          constraints: const BoxConstraints(maxWidth: 800),
+          child: ListView(
+            padding: const EdgeInsets.fromLTRB(16, 12, 16, 32),
             children: [
-              Padding(
-                padding: AppStyle.edgeInsetsA12.copyWith(top: 0),
-                child: Text(
-                  "标签管理",
-                  style: Get.textTheme.titleSmall,
-                ),
-              ),
+              const _SectionHeading(title: '标签管理'),
               SettingsCard(
-                child: Column(
-                  mainAxisSize: MainAxisSize.min,
-                  children: [
-                    SettingsAction(
-                      title: "标签管理",
-                      onTap: controller.showTagsManager,
-                    ),
-                  ],
+                child: SettingsAction(
+                  title: '标签管理',
+                  subtitle: '添加、重命名或调整自定义标签顺序',
+                  onTap: controller.showTagsManager,
                 ),
               ),
-              Padding(
-                padding: AppStyle.edgeInsetsA12.copyWith(top: 24),
-                child: Text(
-                  "关注清理功能",
-                  style: Get.textTheme.titleSmall,
-                ),
-              ),
+              const _SectionHeading(title: '关注清理功能', top: 24),
               SettingsCard(
-                child: Column(
-                  mainAxisSize: MainAxisSize.min,
-                  children: [
-                    // todo：筛选条件设置
-                    // SettingsAction(
-                    //   title: "筛选条件设置",
-                    // ),
-                    SettingsMenuCheck<FollowUser>(
-                      title: '选择要清理的用户',
-                      subtitle: '默认条件为：观看时常低于30分钟，历史观看底部15',
-                      confirmText: '清理',
-                      itemToString: (user) => user.userName, // 告诉组件如何显示用户名
-
-                      // 这里传入您自己的筛选函数
-                      itemsProvider: () async {
-                        return controller.buildAutoCleanPool();
-                      },
-                      // 用户点击“清理”按钮后的回调
-                      onConfirm: (List<FollowUser> selectedUsers) {
-                        controller.cleanFollow(selectedUsers);
-                      },
-                    )
-                  ],
+                child: SettingsMenuCheck<FollowUser>(
+                  title: '选择要清理的用户',
+                  subtitle: '默认条件为：观看时长低于30分钟，历史观看底部15',
+                  confirmText: '清理',
+                  itemToString: (user) => user.userName,
+                  itemsProvider: () async => controller.buildAutoCleanPool(),
+                  onConfirm: controller.cleanFollow,
                 ),
               ),
-              Padding(
-                padding: AppStyle.edgeInsetsA12.copyWith(top: 24),
-                child: Text(
-                  "其他设置",
-                  style: Get.textTheme.titleSmall,
-                ),
-              ),
+              const _SectionHeading(title: '其他设置', top: 24),
               SettingsCard(
                 child: Column(
                   mainAxisSize: MainAxisSize.min,
@@ -92,50 +54,40 @@ class FollowSettingsPage extends GetView<FollowAppSettingsController> {
                     Obx(
                       () => SettingsSwitch(
                         value: controller.appC.hideOfflineFollow.value,
-                        title: "隐藏离线关注",
-                        onChanged: (e) {
-                          controller.setFollowSetting(e);
-                        },
+                        title: '隐藏离线关注',
+                        onChanged: controller.setFollowSetting,
                       ),
                     ),
+                    AppStyle.divider,
                     Obx(
                       () => SettingsSwitch(
                         value: controller.appC.hideRemoveFollowButton.value,
-                        title: "隐藏快速取关按钮",
-                        onChanged: (e) {
-                          controller.setRemoveFollowButton(e);
-                        },
+                        title: '隐藏快速取关按钮',
+                        onChanged: controller.setRemoveFollowButton,
                       ),
                     ),
+                    AppStyle.divider,
                     Obx(
                       () => SettingsSwitch(
                         value: controller.appC.followSnapshotEnable.value,
-                        title: "直播状态快照",
-                        subtitle: "恢复短时间内直播状态，降低风控风险",
-                        onChanged: (e) {
-                          controller.appC.setFollowSnapshotEnable(e);
-                        },
+                        title: '直播状态快照',
+                        subtitle: '恢复短时间内直播状态，降低风控风险',
+                        onChanged: controller.appC.setFollowSnapshotEnable,
                       ),
                     ),
                   ],
                 ),
               ),
-              Padding(
-                padding: AppStyle.edgeInsetsA12.copyWith(top: 24),
-                child: Text(
-                  "自动更新设置",
-                  style: Get.textTheme.titleSmall,
-                ),
-              ),
+              const _SectionHeading(title: '自动更新设置', top: 24),
               SettingsCard(
                 child: Column(
                   children: [
                     Obx(
                       () => SettingsSwitch(
                         value: controller.appC.autoUpdateFollowEnable.value,
-                        title: "自动更新关注直播状态",
-                        onChanged: (e) {
-                          controller.appC.setAutoUpdateFollowEnable(e);
+                        title: '自动更新关注直播状态',
+                        onChanged: (value) {
+                          controller.appC.setAutoUpdateFollowEnable(value);
                           FollowService.instance.initTimer();
                         },
                       ),
@@ -150,12 +102,10 @@ class FollowSettingsPage extends GetView<FollowAppSettingsController> {
                       () => Visibility(
                         visible: controller.appC.autoUpdateFollowEnable.value,
                         child: SettingsAction(
-                          title: "自动更新间隔",
+                          title: '自动更新间隔',
                           value:
-                              "${controller.appC.autoUpdateFollowDuration.value ~/ 60}小时${controller.appC.autoUpdateFollowDuration.value % 60}分钟",
-                          onTap: () {
-                            setTimer(context);
-                          },
+                              '${controller.appC.autoUpdateFollowDuration.value ~/ 60}小时${controller.appC.autoUpdateFollowDuration.value % 60}分钟',
+                          onTap: () => setTimer(context),
                         ),
                       ),
                     ),
@@ -163,75 +113,59 @@ class FollowSettingsPage extends GetView<FollowAppSettingsController> {
                     Obx(
                       () => SettingsNumber(
                         value: controller.appC.updateFollowThreadCount.value,
-                        title: "更新线程数",
-                        subtitle: "多线程可以能更快的完成加载，但可能会因为请求太频繁导致读取状态失败",
+                        title: '更新线程数',
+                        subtitle: '多线程可以更快完成加载，但请求过于频繁可能导致状态读取失败',
                         min: 1,
                         max: 12,
-                        onChanged: (e) {
-                          controller.appC.setUpdateFollowThreadCount(e);
-                        },
+                        onChanged: controller.appC.setUpdateFollowThreadCount,
                       ),
                     ),
                   ],
                 ),
               ),
-              Padding(
-                padding: AppStyle.edgeInsetsA12.copyWith(top: 24),
-                child: Text(
-                  "关注导入导出",
-                  style: Get.textTheme.titleSmall,
-                ),
-              ),
-              fileImportAndExportBuild(),
-              Padding(
-                padding: AppStyle.edgeInsetsA12.copyWith(top: 24),
-                child: Text(
-                  "数据校准",
-                  style: Get.textTheme.titleSmall,
-                ),
-              ),
+              const _SectionHeading(title: '关注导入导出', top: 24),
+              _fileImportAndExportBuild(),
+              const _SectionHeading(title: '数据校准', top: 24),
               SettingsCard(
-                child: Column(
-                  mainAxisSize: MainAxisSize.min,
-                  children: [
-                    SettingsAction(
-                      title: "数据校准",
-                      subtitle: '关注以及标签数据错乱可以点击此功能进行校准，请勿重复点击',
-                      onTap: controller.followDataCheck,
-                    ),
-                  ],
+                child: SettingsAction(
+                  title: '数据校准',
+                  subtitle: '关注以及标签数据错乱时可进行校准，请勿重复点击',
+                  onTap: controller.followDataCheck,
                 ),
               ),
             ],
           ),
-        ],
+        ),
       ),
     );
   }
 
-  Widget fileImportAndExportBuild() {
+  Widget _fileImportAndExportBuild() {
     return SettingsCard(
       child: Column(
         children: [
           SettingsAction(
             leading: const Icon(Remix.save_2_line),
-            title: "导出文件",
-            onTap: () => FollowService.instance.exportFile(),
+            title: '导出文件',
+            onTap: FollowService.instance.exportFile,
           ),
+          AppStyle.divider,
           SettingsAction(
             leading: const Icon(Remix.folder_open_line),
-            title: "导入文件",
-            onTap: () => FollowService.instance.inputFile(),
+            title: '导入文件',
+            onTap: FollowService.instance.inputFile,
           ),
+          AppStyle.divider,
           SettingsAction(
             leading: const Icon(Remix.text),
-            title: "导出文本",
-            onTap: () => FollowService.instance.exportText(),
+            title: '导出文本',
+            onTap: FollowService.instance.exportText,
           ),
+          AppStyle.divider,
           SettingsAction(
             leading: const Icon(Remix.file_text_line),
-            title: "导入文本",
-            onTap: () => FollowService.instance.inputText(),
+            title: '导入文本',
+            onTap: FollowService.instance.inputText,
           ),
         ],
       ),
@@ -239,7 +173,7 @@ class FollowSettingsPage extends GetView<FollowAppSettingsController> {
   }
 
   void setTimer(BuildContext context) async {
-    var value = await showTimePicker(
+    final value = await showTimePicker(
       context: context,
       initialTime: TimeOfDay(
         hour: controller.appC.autoUpdateFollowDuration.value ~/ 60,
@@ -248,18 +182,36 @@ class FollowSettingsPage extends GetView<FollowAppSettingsController> {
       initialEntryMode: TimePickerEntryMode.inputOnly,
       builder: (_, child) {
         return MediaQuery(
-          data: MediaQuery.of(context).copyWith(
-            alwaysUse24HourFormat: true,
-          ),
+          data: MediaQuery.of(context).copyWith(alwaysUse24HourFormat: true),
           child: child!,
         );
       },
     );
-    if (value == null || (value.hour == 0 && value.minute == 0)) {
-      return;
-    }
-    var duration = Duration(hours: value.hour, minutes: value.minute);
+    if (value == null || (value.hour == 0 && value.minute == 0)) return;
+    final duration = Duration(hours: value.hour, minutes: value.minute);
     controller.appC.setAutoUpdateFollowDuration(duration.inMinutes);
     FollowService.instance.initTimer();
+  }
+}
+
+class _SectionHeading extends StatelessWidget {
+  const _SectionHeading({required this.title, this.top = 0});
+
+  final String title;
+  final double top;
+
+  @override
+  Widget build(BuildContext context) {
+    final semantic = context.appTheme;
+    return Padding(
+      padding: EdgeInsets.fromLTRB(4, top, 4, AppDesignTokens.space8),
+      child: Text(
+        title,
+        style: Theme.of(context).textTheme.titleSmall?.copyWith(
+          color: semantic.textSecondary,
+          fontWeight: FontWeight.w700,
+        ),
+      ),
+    );
   }
 }

--- a/simple_live_app/lib/modules/follow_user/follow_info_setting/follow_info_page.dart
+++ b/simple_live_app/lib/modules/follow_user/follow_info_setting/follow_info_page.dart
@@ -2,8 +2,13 @@ import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import 'package:remixicon/remixicon.dart';
 import 'package:simple_live_app/app/app_style.dart';
+import 'package:simple_live_app/app/design_system/app_design_tokens.dart';
+import 'package:simple_live_app/app/design_system/app_theme_extension.dart';
 import 'package:simple_live_app/app/sites.dart';
 import 'package:simple_live_app/modules/follow_user/follow_info_setting/follow_info_controller.dart';
+import 'package:simple_live_app/widgets/net_image.dart';
+import 'package:simple_live_app/widgets/settings/settings_action.dart';
+import 'package:simple_live_app/widgets/settings/settings_card.dart';
 import 'package:simple_live_app/widgets/settings/settings_menu.dart';
 
 class FollowInfoPage extends GetView<FollowInfoController> {
@@ -12,235 +17,275 @@ class FollowInfoPage extends GetView<FollowInfoController> {
   @override
   Widget build(BuildContext context) {
     final site = Sites.allSites[controller.followUser.value!.siteId]!;
+    final theme = Theme.of(context);
+    final semantic = context.appTheme;
+
     return Scaffold(
       appBar: AppBar(
-        title: const Text("关注信息设置"),
+        title: const Text('关注信息设置'),
         actions: [
           Obx(
             () => controller.pageLoadding.value
                 ? const IconButton(
                     onPressed: null,
+                    tooltip: '正在刷新',
                     icon: SizedBox(
                       width: 16,
                       height: 16,
-                      child: CircularProgressIndicator(
-                        strokeWidth: 2,
-                      ),
+                      child: CircularProgressIndicator(strokeWidth: 2),
                     ),
                   )
                 : IconButton(
-                    onPressed: () {
-                      controller.refreshData();
-                    },
-                    icon: const Icon(Icons.refresh),
+                    onPressed: controller.refreshData,
+                    tooltip: '刷新用户信息',
+                    icon: const Icon(Icons.refresh_rounded),
                   ),
+          ),
+          const SizedBox(width: AppDesignTokens.space8),
+        ],
+      ),
+      body: Align(
+        alignment: Alignment.topCenter,
+        child: ConstrainedBox(
+          constraints: const BoxConstraints(maxWidth: 800),
+          child: ListView(
+            padding: const EdgeInsets.fromLTRB(16, 12, 16, 32),
+            children: [
+              SettingsCard(
+                child: Padding(
+                  padding: const EdgeInsets.all(AppDesignTokens.space16),
+                  child: Obx(
+                    () => Row(
+                      children: [
+                        NetImage(
+                          controller.followUser.value!.face,
+                          width: 56,
+                          height: 56,
+                          borderRadius: 28,
+                        ),
+                        const SizedBox(width: AppDesignTokens.space12),
+                        Expanded(
+                          child: Column(
+                            crossAxisAlignment: CrossAxisAlignment.start,
+                            children: [
+                              Text(
+                                controller.followUser.value!.remark?.isNotEmpty ==
+                                        true
+                                    ? '${controller.followUser.value!.userName} (${controller.followUser.value!.remark!})'
+                                    : controller.followUser.value!.userName,
+                                maxLines: 2,
+                                overflow: TextOverflow.ellipsis,
+                                style: theme.textTheme.titleMedium?.copyWith(
+                                  color: semantic.textPrimary,
+                                  fontWeight: FontWeight.w700,
+                                ),
+                              ),
+                              const SizedBox(height: AppDesignTokens.space4),
+                              Row(
+                                children: [
+                                  Image.asset(site.logo, width: 18, height: 18),
+                                  const SizedBox(width: AppDesignTokens.space8),
+                                  Expanded(
+                                    child: Text(
+                                      '${site.name} · 房间号 ${controller.followUser.value!.roomId}',
+                                      maxLines: 1,
+                                      overflow: TextOverflow.ellipsis,
+                                      style: theme.textTheme.bodySmall?.copyWith(
+                                        color: semantic.textSecondary,
+                                      ),
+                                    ),
+                                  ),
+                                ],
+                              ),
+                            ],
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                ),
+              ),
+              const _SectionHeading(title: '基本信息', top: 24),
+              SettingsCard(
+                child: Column(
+                  children: [
+                    Obx(() {
+                      final items = controller.tagOptions;
+                      final selected = controller.selectedTag.value;
+                      final valueMap = <String, String>{
+                        for (final item in items) item.tag: item.tag,
+                      };
+                      return SettingsMenu<String>(
+                        title: '标签设置',
+                        value: selected?.tag ?? '全部',
+                        valueMap: valueMap,
+                        onChanged: (value) {
+                          final target = items.firstWhere(
+                            (item) => item.tag == value,
+                            orElse: () => items.first,
+                          );
+                          controller.changeTag(target);
+                        },
+                      );
+                    }),
+                    AppStyle.divider,
+                    Obx(
+                      () => SettingsAction(
+                        title: '备注设置',
+                        value:
+                            controller.followUser.value?.remark?.isNotEmpty == true
+                                ? controller.followUser.value!.remark!
+                                : '无',
+                        onTap: () => _showRemarkDialog(context),
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+              const _SectionHeading(title: '平台迁移', top: 24),
+              SettingsCard(
+                child: Padding(
+                  padding: const EdgeInsets.all(AppDesignTokens.space16),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.stretch,
+                    children: [
+                      Row(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Icon(
+                            Remix.link,
+                            size: 20,
+                            color: semantic.textSecondary,
+                          ),
+                          const SizedBox(width: AppDesignTokens.space8),
+                          Expanded(
+                            child: Text(
+                              '输入主播在新平台的直播链接，解析后迁移关注信息',
+                              style: theme.textTheme.bodyMedium?.copyWith(
+                                color: semantic.textSecondary,
+                              ),
+                            ),
+                          ),
+                        ],
+                      ),
+                      const SizedBox(height: AppDesignTokens.space12),
+                      LayoutBuilder(
+                        builder: (context, constraints) {
+                          final field = TextField(
+                            controller: controller.migrationUrlController,
+                            decoration: const InputDecoration(
+                              hintText: '粘贴新平台直播间链接，如 https://...',
+                              border: OutlineInputBorder(),
+                            ),
+                            onSubmitted: (_) => controller.parseAndMigrate(),
+                          );
+                          final actions = Row(
+                            mainAxisSize: MainAxisSize.min,
+                            children: [
+                              IconButton(
+                                tooltip: '粘贴',
+                                onPressed: controller.pasteFromClipboard,
+                                icon: const Icon(Remix.clipboard_line),
+                              ),
+                              const SizedBox(width: AppDesignTokens.space8),
+                              FilledButton.icon(
+                                onPressed: controller.parseAndMigrate,
+                                icon: const Icon(Remix.arrow_right_line),
+                                label: const Text('迁移'),
+                              ),
+                            ],
+                          );
+                          if (constraints.maxWidth < 560) {
+                            return Column(
+                              crossAxisAlignment: CrossAxisAlignment.stretch,
+                              children: [
+                                field,
+                                const SizedBox(height: AppDesignTokens.space8),
+                                Align(
+                                  alignment: Alignment.centerRight,
+                                  child: actions,
+                                ),
+                              ],
+                            );
+                          }
+                          return Row(
+                            children: [
+                              Expanded(child: field),
+                              const SizedBox(width: AppDesignTokens.space8),
+                              actions,
+                            ],
+                          );
+                        },
+                      ),
+                      const SizedBox(height: AppDesignTokens.space12),
+                      Text(
+                        'other todo ...',
+                        style: theme.textTheme.bodySmall?.copyWith(
+                          color: semantic.textTertiary,
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  void _showRemarkDialog(BuildContext context) {
+    final textController = TextEditingController(
+      text: controller.followUser.value?.remark,
+    );
+    Get.dialog(
+      AlertDialog(
+        title: const Text('修改备注'),
+        content: TextField(
+          controller: textController,
+          decoration: const InputDecoration(
+            border: OutlineInputBorder(),
+            hintText: '请输入备注名',
+          ),
+          autofocus: true,
+          onSubmitted: (value) {
+            controller.updateRemark(value.trim());
+            Get.back();
+          },
+        ),
+        actions: [
+          TextButton(onPressed: Get.back, child: const Text('取消')),
+          FilledButton(
+            onPressed: () {
+              controller.updateRemark(textController.text.trim());
+              Get.back();
+            },
+            child: const Text('确定'),
           ),
         ],
       ),
-      body: Column(
-        crossAxisAlignment: CrossAxisAlignment.stretch,
-        children: [
-          // 顶部：头像+平台+房间号
-          Padding(
-            padding: AppStyle.edgeInsetsA12,
-            child: Obx(
-              () => Row(
-                children: [
-                  CircleAvatar(
-                    radius: 28,
-                    backgroundImage:
-                        NetworkImage(controller.followUser.value!.face),
-                  ),
-                  AppStyle.hGap12,
-                  Expanded(
-                    child: Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        Text(
-                          controller.followUser.value!.remark?.isNotEmpty ==
-                                  true
-                              ? '${controller.followUser.value!.userName} (${controller.followUser.value!.remark!})'
-                              : controller.followUser.value!.userName,
-                          style: const TextStyle(
-                            fontSize: 18,
-                            fontWeight: FontWeight.w600,
-                          ),
-                          maxLines: 1,
-                          overflow: TextOverflow.ellipsis,
-                        ),
-                        AppStyle.vGap4,
-                        Row(
-                          children: [
-                            Image.asset(site.logo, width: 18),
-                            AppStyle.hGap8,
-                            Flexible(
-                              child: Text(
-                                '${site.name}  房间号：${controller.followUser.value!.roomId}',
-                                style: TextStyle(
-                                  fontSize: 12,
-                                  color: Theme.of(context)
-                                      .textTheme
-                                      .bodySmall
-                                      ?.color
-                                      ?.withValues(alpha: .7),
-                                ),
-                                maxLines: 1,
-                                overflow: TextOverflow.ellipsis,
-                              ),
-                            ),
-                          ],
-                        ),
-                      ],
-                    ),
-                  ),
-                ],
-              ),
-            ),
-          ),
-          AppStyle.divider,
-          // 标签设置：底部弹出选择
-          Padding(
-            padding: AppStyle.edgeInsetsA12,
-            child: Obx(() {
-              final items = controller.tagOptions;
-              final selected = controller.selectedTag.value;
-              final Map<String, String> valueMap = {
-                for (final t in items) t.tag: t.tag,
-              };
-              return SettingsMenu<String>(
-                title: '标签设置',
-                value: selected?.tag ?? '全部',
-                valueMap: valueMap,
-                onChanged: (value) {
-                  final target = items.firstWhere(
-                    (e) => e.tag == value,
-                    orElse: () => items.first,
-                  );
-                  controller.changeTag(target);
-                },
-              );
-            }),
-          ),
-          AppStyle.divider,
-          Padding(
-            padding: AppStyle.edgeInsetsA12,
-            child: Obx(() {
-              return ListTile(
-                title:
-                    Text('备注设置', style: Theme.of(context).textTheme.bodyLarge),
-                visualDensity: VisualDensity.compact,
-                shape: RoundedRectangleBorder(
-                  borderRadius: AppStyle.radius8,
-                ),
-                contentPadding: AppStyle.edgeInsetsL16.copyWith(right: 8),
-                trailing: Row(
-                  mainAxisSize: MainAxisSize.min,
-                  children: [
-                    Text(
-                      controller.followUser.value?.remark?.isNotEmpty == true
-                          ? controller.followUser.value!.remark!
-                          : '无',
-                      style: Theme.of(context)
-                          .textTheme
-                          .bodyMedium!
-                          .copyWith(color: Colors.grey),
-                    ),
-                    AppStyle.hGap4,
-                    const Icon(
-                      Icons.chevron_right,
-                      color: Colors.grey,
-                    ),
-                  ],
-                ),
-                onTap: () {
-                  final textController = TextEditingController(
-                      text: controller.followUser.value?.remark);
-                  Get.dialog(
-                    AlertDialog(
-                      title: const Text("修改备注"),
-                      content: TextField(
-                        controller: textController,
-                        decoration: const InputDecoration(
-                            border: OutlineInputBorder(), hintText: "请输入备注名"),
-                        autofocus: true,
-                        onSubmitted: (value) {
-                          controller.updateRemark(value.trim());
-                          Get.back();
-                        },
-                      ),
-                      actions: [
-                        TextButton(
-                          onPressed: () => Get.back(),
-                          child: const Text("取消"),
-                        ),
-                        TextButton(
-                          onPressed: () {
-                            controller.updateRemark(textController.text.trim());
-                            Get.back();
-                          },
-                          child: const Text("确定"),
-                        ),
-                      ],
-                    ),
-                  );
-                },
-              );
-            }),
-          ),
-          AppStyle.divider,
-          // 平台迁移：输入链接解析
-          Padding(
-            padding: AppStyle.edgeInsetsA12,
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Row(
-                  children: const [
-                    Icon(Remix.link),
-                    SizedBox(width: 8),
-                    Text('平台迁移（输入直播链接进行解析）'),
-                  ],
-                ),
-                AppStyle.vGap8,
-                Row(
-                  children: [
-                    Expanded(
-                      child: TextField(
-                        controller: controller.migrationUrlController,
-                        decoration: const InputDecoration(
-                          hintText: '粘贴主播在新平台的直播间链接，如 https://... ',
-                          border: OutlineInputBorder(),
-                          isDense: true,
-                          contentPadding: EdgeInsets.symmetric(
-                            horizontal: 12,
-                            vertical: 10,
-                          ),
-                        ),
-                        onSubmitted: (_) => controller.parseAndMigrate(),
-                      ),
-                    ),
-                    AppStyle.vGap8,
-                    IconButton(
-                      tooltip: '粘贴',
-                      onPressed: controller.pasteFromClipboard,
-                      icon: const Icon(Remix.clipboard_line),
-                    ),
-                    ElevatedButton.icon(
-                      onPressed: controller.parseAndMigrate,
-                      icon: const Icon(Remix.arrow_right_line),
-                      label: const Text('迁移'),
-                    ),
-                  ],
-                ),
-                AppStyle.vGap12,
-                Text(
-                  "other todo ...",
-                  style: TextStyle(color: Colors.grey),
-                )
-              ],
-            ),
-          ),
-        ],
+    );
+  }
+}
+
+class _SectionHeading extends StatelessWidget {
+  const _SectionHeading({required this.title, this.top = 0});
+
+  final String title;
+  final double top;
+
+  @override
+  Widget build(BuildContext context) {
+    final semantic = context.appTheme;
+    return Padding(
+      padding: EdgeInsets.fromLTRB(4, top, 4, AppDesignTokens.space8),
+      child: Text(
+        title,
+        style: Theme.of(context).textTheme.titleSmall?.copyWith(
+          color: semantic.textSecondary,
+          fontWeight: FontWeight.w700,
+        ),
       ),
     );
   }

--- a/simple_live_app/lib/modules/follow_user/follow_user_page.dart
+++ b/simple_live_app/lib/modules/follow_user/follow_user_page.dart
@@ -2,7 +2,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter_smart_dialog/flutter_smart_dialog.dart';
 import 'package:get/get.dart';
 import 'package:remixicon/remixicon.dart';
-import 'package:simple_live_app/app/app_style.dart';
+import 'package:simple_live_app/app/design_system/app_design_tokens.dart';
+import 'package:simple_live_app/app/design_system/app_theme_extension.dart';
 import 'package:simple_live_app/app/controller/app_settings_controller.dart';
 import 'package:simple_live_app/app/sites.dart';
 import 'package:simple_live_app/modules/follow_user/follow_user_controller.dart';
@@ -21,76 +22,63 @@ class FollowUserPage extends GetView<FollowUserController> {
 
   @override
   Widget build(BuildContext context) {
-    var count = MediaQuery
-        .of(context)
-        .size
-        .width ~/ 500;
-    if (count < 1) count = 1;
-    var c = MediaQuery
-        .of(context)
-        .size
-        .width ~/ 200;
-    if (c < 2) {
-      c = 2;
-    }
+    final theme = Theme.of(context);
+    final semantic = context.appTheme;
+
     return Scaffold(
       appBar: AppBar(
-        title: const Text("关注用户"),
+        centerTitle: false,
+        titleSpacing: AppDesignTokens.space24,
+        toolbarHeight: 68,
+        title: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Text(
+              '关注用户',
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+              style: theme.textTheme.headlineSmall?.copyWith(
+                color: semantic.textPrimary,
+                fontWeight: FontWeight.w700,
+              ),
+            ),
+            Text(
+              '实时状态与分组',
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+              style: theme.textTheme.labelMedium?.copyWith(
+                color: semantic.textTertiary,
+              ),
+            ),
+          ],
+        ),
         actions: [
-          PopupMenuButton(
-            itemBuilder: (context) {
-              return const [
-                PopupMenuItem(
-                  value: 0,
-                  child: Row(
-                    mainAxisSize: MainAxisSize.min,
-                    children: [
-                      Icon(Remix.trophy_line),
-                      AppStyle.hGap12,
-                      Text("赛事订阅"),
-                    ],
-                  ),
-                ),
-                PopupMenuItem(
-                  value: 1,
-                  child: Row(
-                    mainAxisSize: MainAxisSize.min,
-                    children: [
-                      Icon(Remix.blender_line),
-                      AppStyle.hGap12,
-                      Text("模式切换"),
-                    ],
-                  ),
-                ),
-                PopupMenuItem(
-                  value: 2,
-                  child: Row(
-                    mainAxisSize: MainAxisSize.min,
-                    children: [
-                      Icon(Remix.sort_asc),
-                      AppStyle.hGap12,
-                      Text("按序排列"),
-                    ],
-                  ),
-                ),
-                PopupMenuItem(
-                  value: 4,
-                  child: Row(
-                    mainAxisSize: MainAxisSize.min,
-                    children: [
-                      Icon(Remix.heart_line),
-                      AppStyle.hGap12,
-                      Text("关注设置"),
-                    ],
-                  ),
-                ),
-              ];
-            },
+          PopupMenuButton<int>(
+            tooltip: '关注菜单',
+            itemBuilder: (context) => const [
+              PopupMenuItem(
+                value: 0,
+                child: _MenuItem(icon: Remix.trophy_line, label: '赛事订阅'),
+              ),
+              PopupMenuItem(
+                value: 1,
+                child: _MenuItem(icon: Remix.blender_line, label: '模式切换'),
+              ),
+              PopupMenuItem(
+                value: 2,
+                child: _MenuItem(icon: Remix.sort_asc, label: '按序排列'),
+              ),
+              PopupMenuItem(
+                value: 4,
+                child: _MenuItem(icon: Remix.heart_line, label: '关注设置'),
+              ),
+            ],
             onSelected: (value) {
               if (value == 4) {
                 Get.toNamed(RoutePath.kSettingsFollow);
               } else if (value == 0) {
-                SmartDialog.showToast("此功能暂未开放！敬请期待！");
+                SmartDialog.showToast('此功能暂未开放！敬请期待！');
               } else if (value == 1) {
                 controller.showFollowStyleDialog();
               } else if (value == 2) {
@@ -98,131 +86,187 @@ class FollowUserPage extends GetView<FollowUserController> {
               }
             },
           ),
+          const SizedBox(width: AppDesignTokens.space8),
         ],
         leading: Obx(
           () => FollowService.instance.updating.value
               ? const IconButton(
                   onPressed: null,
+                  tooltip: '正在刷新',
                   icon: SizedBox(
                     width: 16,
                     height: 16,
-                    child: CircularProgressIndicator(
-                      strokeWidth: 2,
-                    ),
+                    child: CircularProgressIndicator(strokeWidth: 2),
                   ),
                 )
               : IconButton(
-                  onPressed: () {
-                    controller.refreshData();
-                  },
-                  icon: const Icon(Icons.refresh),
+                  onPressed: controller.refreshData,
+                  tooltip: '刷新关注状态',
+                  icon: const Icon(Icons.refresh_rounded),
                 ),
         ),
       ),
       body: Column(
         crossAxisAlignment: CrossAxisAlignment.stretch,
         children: [
-          Padding(
-            padding: AppStyle.edgeInsetsL8,
-            child: Row(
-              children: [
-                Expanded(
-                  child: Obx(
-                        () =>
-                        SingleChildScrollView(
-                          scrollDirection: Axis.horizontal,
-                          child: Wrap(
-                            spacing: 12,
-                            children: controller.tagList.map(
-                                  (option) {
-                                return FilterButton(
-                                  text: option.tag,
-                                  selected: controller.filterMode.value ==
-                                      option,
-                                  onTap: () {
-                                    controller.setFilterMode(option);
-                                  },
-                                );
-                              },
-                            ).toList(),
-                          ),
-                        ),
-                  ),
-                ),
-              ],
+          DecoratedBox(
+            decoration: BoxDecoration(
+              border: Border(bottom: BorderSide(color: semantic.divider)),
             ),
-          ),
-          Obx(
-            () => Expanded(
-              child: AppSettingsController.instance.followStyleNotGrid.value
-                  ? PageGridView(
-                      crossAxisSpacing: 12,
-                      crossAxisCount: count,
-                      pageController: controller,
-                      firstRefresh: true,
-                      showPCRefreshButton: false,
-                      itemBuilder: (_, i) {
-                        var item = controller.list[i];
-                        var site = Sites.allSites[item.siteId]!;
-                        return FollowUserItem(
-                          item: item,
-                          onRemove: () {
-                            controller.removeFollow(item);
-                          },
-                          onTap: () {
-                            AppNavigator.toLiveRoomDetail(
-                                site: site, roomId: item.roomId);
-                          },
-                          onLongPress: () {
-                            // 长按弹出操作：设置标签或查看详情
-                            controller.showBottomMenu(item);
-                          },
+            child: Align(
+              alignment: Alignment.center,
+              child: ConstrainedBox(
+                constraints: const BoxConstraints(maxWidth: 1280),
+                child: SizedBox(
+                  height: 54,
+                  child: Obx(
+                    () => ListView.separated(
+                      scrollDirection: Axis.horizontal,
+                      padding: const EdgeInsets.symmetric(
+                        horizontal: AppDesignTokens.space16,
+                        vertical: AppDesignTokens.space8,
+                      ),
+                      itemCount: controller.tagList.length,
+                      separatorBuilder: (_, __) =>
+                          const SizedBox(width: AppDesignTokens.space8),
+                      itemBuilder: (_, index) {
+                        final option = controller.tagList[index];
+                        return FilterButton(
+                          text: option.tag,
+                          selected: controller.filterMode.value == option,
+                          onTap: () => controller.setFilterMode(option),
                         );
                       },
-                    )
-                  : KeepAliveWrapper(
-                      child: Obx(
-                        () {
-                          // temp
-                          final hide = AppSettingsController
-                              .instance.hideRemoveFollowButton.value;
-                          return PageGridView(
-                            pageController: controller,
-                            padding: AppStyle.edgeInsetsA12,
-                            firstRefresh: true,
-                            mainAxisSpacing: 12,
-                            crossAxisSpacing: 12,
-                            crossAxisCount: c,
-                            itemBuilder: (_, i) {
-                              var item = controller.list[i];
-                              // 或许直接继承字段更好，标记工作
-                              LiveRoomItem liveRoomItem = LiveRoomItem(
-                                roomId: item.roomId,
-                                title: item.title.value,
-                                cover: item.cover.value,
-                                userName: item.userName,
-                                online: item.online.value,
-                              );
-                              var site = Sites.allSites[item.siteId]!;
-                              return LiveRoomCard(
-                                site,
-                                liveRoomItem,
-                                onFollowRemove: hide
-                                    ? null
-                                    : () => controller.removeFollow(item),
-                                onLongPress: () {
-                                  controller.showBottomMenu(item);
-                                },
-                              );
-                            },
-                          );
-                        },
-                      ),
                     ),
+                  ),
+                ),
+              ),
+            ),
+          ),
+          Expanded(
+            child: LayoutBuilder(
+              builder: (context, constraints) {
+                final viewportWidth = constraints.maxWidth > 1280
+                    ? 1280.0
+                    : constraints.maxWidth;
+                final availableWidth = viewportWidth - 32;
+                var listColumns = (availableWidth / 460).floor();
+                if (listColumns < 1) listColumns = 1;
+                if (listColumns > 2) listColumns = 2;
+                var cardColumns = (availableWidth / 260).floor();
+                if (cardColumns < 2) cardColumns = 2;
+                if (cardColumns > 5) cardColumns = 5;
+
+                return Obx(
+                  () => Align(
+                    alignment: Alignment.topCenter,
+                    child: SizedBox(
+                      width: viewportWidth,
+                      child: AppSettingsController
+                              .instance.followStyleNotGrid.value
+                          ? PageGridView(
+                              padding: const EdgeInsets.fromLTRB(16, 16, 16, 24),
+                              mainAxisSpacing: AppDesignTokens.space8,
+                              crossAxisSpacing: AppDesignTokens.space8,
+                              crossAxisCount: listColumns,
+                              pageController: controller,
+                              firstRefresh: true,
+                              showPCRefreshButton: false,
+                              itemBuilder: (_, i) {
+                                final item = controller.list[i];
+                                final site = Sites.allSites[item.siteId]!;
+                                return DecoratedBox(
+                                  decoration: BoxDecoration(
+                                    color: semantic.secondarySurface,
+                                    borderRadius: BorderRadius.circular(
+                                      AppDesignTokens.radius12,
+                                    ),
+                                    border: Border.all(color: semantic.border),
+                                  ),
+                                  child: FollowUserItem(
+                                    item: item,
+                                    onRemove: () =>
+                                        controller.removeFollow(item),
+                                    onTap: () {
+                                      AppNavigator.toLiveRoomDetail(
+                                        site: site,
+                                        roomId: item.roomId,
+                                      );
+                                    },
+                                    onLongPress: () =>
+                                        controller.showBottomMenu(item),
+                                  ),
+                                );
+                              },
+                            )
+                          : KeepAliveWrapper(
+                              child: Obx(
+                                () {
+                                  final hide = AppSettingsController.instance
+                                      .hideRemoveFollowButton.value;
+                                  return PageGridView(
+                                    pageController: controller,
+                                    padding: const EdgeInsets.fromLTRB(
+                                      16,
+                                      16,
+                                      16,
+                                      24,
+                                    ),
+                                    firstRefresh: true,
+                                    mainAxisSpacing: AppDesignTokens.space16,
+                                    crossAxisSpacing: AppDesignTokens.space16,
+                                    crossAxisCount: cardColumns,
+                                    itemBuilder: (_, i) {
+                                      final item = controller.list[i];
+                                      final liveRoomItem = LiveRoomItem(
+                                        roomId: item.roomId,
+                                        title: item.title.value,
+                                        cover: item.cover.value,
+                                        userName: item.userName,
+                                        online: item.online.value,
+                                      );
+                                      final site = Sites.allSites[item.siteId]!;
+                                      return LiveRoomCard(
+                                        site,
+                                        liveRoomItem,
+                                        onFollowRemove: hide
+                                            ? null
+                                            : () => controller.removeFollow(item),
+                                        onLongPress: () =>
+                                            controller.showBottomMenu(item),
+                                      );
+                                    },
+                                  );
+                                },
+                              ),
+                            ),
+                    ),
+                  ),
+                );
+              },
             ),
           ),
         ],
       ),
+    );
+  }
+}
+
+class _MenuItem extends StatelessWidget {
+  const _MenuItem({required this.icon, required this.label});
+
+  final IconData icon;
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Icon(icon, size: 20),
+        const SizedBox(width: AppDesignTokens.space12),
+        Text(label),
+      ],
     );
   }
 }

--- a/simple_live_app/lib/modules/home/home_list_view.dart
+++ b/simple_live_app/lib/modules/home/home_list_view.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
-
 import 'package:get/get.dart';
-import 'package:simple_live_app/app/app_style.dart';
+import 'package:simple_live_app/app/design_system/app_design_tokens.dart';
 import 'package:simple_live_app/modules/home/home_list_controller.dart';
 import 'package:simple_live_app/widgets/keep_alive_wrapper.dart';
 import 'package:simple_live_app/widgets/live_room_card.dart';
@@ -10,26 +9,57 @@ import 'package:simple_live_app/widgets/page_grid_view.dart';
 class HomeListView extends StatelessWidget {
   final String tag;
   const HomeListView(this.tag, {super.key});
+
   HomeListController get controller => Get.find<HomeListController>(tag: tag);
+
   @override
   Widget build(BuildContext context) {
-    var c = MediaQuery.of(context).size.width ~/ 200;
-    if (c < 2) {
-      c = 2;
-    }
     return KeepAliveWrapper(
-      child: PageGridView(
-        pageController: controller,
-        padding: AppStyle.edgeInsetsA12,
-        firstRefresh: true,
-        mainAxisSpacing: 12,
-        crossAxisSpacing: 12,
-        crossAxisCount: c,
-        itemBuilder: (_, i) {
-          var item = controller.list[i];
-          return LiveRoomCard(controller.site, item);
+      child: LayoutBuilder(
+        builder: (context, constraints) {
+          const targetCardWidth = 280.0;
+          const spacing = AppDesignTokens.space16;
+          const maxColumnCount = 5;
+          final gutter = _contentGutter(constraints.maxWidth);
+          final maxViewportWidth = (targetCardWidth * maxColumnCount) +
+              (spacing * (maxColumnCount - 1)) +
+              (gutter * 2);
+          final viewportWidth = constraints.maxWidth > maxViewportWidth
+              ? maxViewportWidth
+              : constraints.maxWidth;
+          final availableWidth = viewportWidth - (gutter * 2);
+          var columnCount =
+              ((availableWidth + spacing) / (targetCardWidth + spacing))
+                  .floor();
+          if (columnCount < 1) columnCount = 1;
+          if (columnCount > maxColumnCount) columnCount = maxColumnCount;
+
+          return Align(
+            alignment: Alignment.topCenter,
+            child: SizedBox(
+              width: viewportWidth,
+              child: PageGridView(
+                pageController: controller,
+                padding: EdgeInsets.fromLTRB(gutter, 20, gutter, 24),
+                firstRefresh: true,
+                mainAxisSpacing: spacing,
+                crossAxisSpacing: spacing,
+                crossAxisCount: columnCount,
+                itemBuilder: (_, i) {
+                  final item = controller.list[i];
+                  return LiveRoomCard(controller.site, item);
+                },
+              ),
+            ),
+          );
         },
       ),
     );
+  }
+
+  double _contentGutter(double width) {
+    if (width >= 1200) return 32;
+    if (width >= 720) return 24;
+    return 12;
   }
 }

--- a/simple_live_app/lib/modules/home/home_page.dart
+++ b/simple_live_app/lib/modules/home/home_page.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
-import 'package:simple_live_app/app/app_style.dart';
+import 'package:simple_live_app/app/design_system/app_design_tokens.dart';
+import 'package:simple_live_app/app/design_system/app_theme_extension.dart';
 import 'package:simple_live_app/app/sites.dart';
 import 'package:simple_live_app/modules/home/home_controller.dart';
 import 'package:simple_live_app/modules/home/home_list_view.dart';
@@ -10,50 +11,106 @@ class HomePage extends GetView<HomeController> {
 
   @override
   Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final semantic = context.appTheme;
+
     return Scaffold(
       appBar: AppBar(
-        titleSpacing: 8,
-        title: TabBar(
-          controller: controller.tabController,
-          labelPadding: AppStyle.edgeInsetsH20,
-          isScrollable: true,
-          indicatorSize: TabBarIndicatorSize.label,
-          tabAlignment: TabAlignment.center,
-          tabs: Sites.supportSites
-              .map(
-                (e) => Tab(
-                  //text: e.name,
-
-                  child: Row(
-                    children: [
-                      Image.asset(
-                        e.logo,
-                        width: 24,
-                      ),
-                      AppStyle.hGap8,
-                      Text(e.name),
-                    ],
-                  ),
-                ),
-              )
-              .toList(),
+        centerTitle: false,
+        titleSpacing: AppDesignTokens.space24,
+        toolbarHeight: 68,
+        title: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Text(
+              '发现直播',
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+              style: theme.textTheme.headlineSmall?.copyWith(
+                color: semantic.textPrimary,
+                fontWeight: FontWeight.w700,
+              ),
+            ),
+            Text(
+              '精选推荐',
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+              style: theme.textTheme.labelMedium?.copyWith(
+                color: semantic.textTertiary,
+              ),
+            ),
+          ],
         ),
         actions: [
           IconButton(
             onPressed: controller.toSearch,
-            icon: const Icon(Icons.search),
-          )
+            tooltip: '搜索直播间或主播',
+            icon: const Icon(Icons.search_rounded),
+          ),
+          const SizedBox(width: AppDesignTokens.space8),
         ],
+        bottom: PreferredSize(
+          preferredSize: const Size.fromHeight(48),
+          child: DecoratedBox(
+            decoration: BoxDecoration(
+              border: Border(
+                bottom: BorderSide(color: semantic.border),
+              ),
+            ),
+            child: SizedBox(
+              height: 48,
+              width: double.infinity,
+              child: TabBar(
+                controller: controller.tabController,
+                isScrollable: true,
+                tabAlignment: TabAlignment.start,
+                indicatorSize: TabBarIndicatorSize.label,
+                labelPadding: const EdgeInsets.symmetric(
+                  horizontal: AppDesignTokens.space12,
+                ),
+                tabs: Sites.supportSites.map(_SiteTab.new).toList(),
+              ),
+            ),
+          ),
+        ),
       ),
       body: TabBarView(
         controller: controller.tabController,
         children: Sites.supportSites
             .map(
-              (e) => HomeListView(
-                e.id,
-              ),
+              (site) => HomeListView(site.id),
             )
             .toList(),
+      ),
+    );
+  }
+}
+
+class _SiteTab extends StatelessWidget {
+  const _SiteTab(this.site);
+
+  final Site site;
+
+  @override
+  Widget build(BuildContext context) {
+    return Tab(
+      height: 40,
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Image.asset(
+            site.logo,
+            width: 20,
+            height: 20,
+          ),
+          const SizedBox(width: AppDesignTokens.space8),
+          Text(
+            site.name,
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
+          ),
+        ],
       ),
     );
   }

--- a/simple_live_app/lib/modules/indexed/indexed_page.dart
+++ b/simple_live_app/lib/modules/indexed/indexed_page.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
-import 'package:simple_live_app/app/app_style.dart';
+import 'package:simple_live_app/app/design_system/app_design_tokens.dart';
+import 'package:simple_live_app/app/design_system/app_theme_extension.dart';
 
 import 'indexed_controller.dart';
 
@@ -11,69 +12,120 @@ class IndexedPage extends GetView<IndexedController> {
   Widget build(BuildContext context) {
     return OrientationBuilder(
       builder: (context, orientation) {
+        final isLandscape = orientation == Orientation.landscape;
+        final theme = Theme.of(context);
+        final semantic = context.appTheme;
+
         return Scaffold(
           body: Row(
             children: [
               Visibility(
-                visible: orientation == Orientation.landscape,
-                child: Obx(
-                  () => NavigationRail(
-                    selectedIndex: controller.index.value,
-                    onDestinationSelected: controller.setIndex,
-                    labelType: NavigationRailLabelType.none,
-                    destinations: controller.items
-                        .map(
-                          (item) => NavigationRailDestination(
-                            icon: Icon(item.iconData),
-                            label: Text(item.title),
-                            padding: AppStyle.edgeInsetsV8,
+                visible: isLandscape,
+                replacement: const SizedBox.shrink(),
+                child: DecoratedBox(
+                  decoration: BoxDecoration(
+                    color: semantic.body,
+                    border: Border(
+                      right: BorderSide(color: semantic.border),
+                    ),
+                  ),
+                  child: SafeArea(
+                    right: false,
+                    child: SizedBox(
+                      width: 76,
+                      child: Obx(
+                        () => NavigationRail(
+                          backgroundColor: Colors.transparent,
+                          selectedIndex: controller.index.value,
+                          onDestinationSelected: controller.setIndex,
+                          minWidth: 76,
+                          groupAlignment: -0.45,
+                          labelType: NavigationRailLabelType.none,
+                          useIndicator: true,
+                          indicatorColor:
+                              theme.colorScheme.primary.withAlpha(20),
+                          indicatorShape: RoundedRectangleBorder(
+                            borderRadius: BorderRadius.circular(
+                              AppDesignTokens.radius12,
+                            ),
                           ),
-                        )
-                        .toList(),
+                          destinations: controller.items
+                              .map(
+                                (item) => NavigationRailDestination(
+                                  icon: Tooltip(
+                                    message: item.title,
+                                    child: Icon(item.iconData),
+                                  ),
+                                  selectedIcon: Tooltip(
+                                    message: item.title,
+                                    child: Icon(
+                                      item.iconData,
+                                      color: theme.colorScheme.primary,
+                                    ),
+                                  ),
+                                  label: Text(
+                                    item.title,
+                                    maxLines: 1,
+                                    overflow: TextOverflow.ellipsis,
+                                  ),
+                                  padding: const EdgeInsets.symmetric(
+                                    vertical: AppDesignTokens.space4,
+                                  ),
+                                ),
+                              )
+                              .toList(),
+                        ),
+                      ),
+                    ),
                   ),
                 ),
               ),
               Expanded(
                 child: Obx(
-                  () => Container(
-                    decoration: BoxDecoration(
-                      border: Border(
-                        left: orientation == Orientation.landscape
-                            ? BorderSide(
-                                color: Colors.grey.withAlpha(50),
-                                width: 1,
-                              )
-                            : BorderSide.none,
-                      ),
-                    ),
-                    child: IndexedStack(
-                      index: controller.index.value,
-                      children: controller.pages,
-                    ),
+                  () => IndexedStack(
+                    index: controller.index.value,
+                    children: controller.pages,
                   ),
                 ),
               ),
             ],
           ),
-          bottomNavigationBar: Visibility(
-            visible: orientation == Orientation.portrait,
-            child: Obx(
-              () => NavigationBar(
-                selectedIndex: controller.index.value,
-                onDestinationSelected: controller.setIndex,
-                height: 56,
-                labelBehavior: NavigationDestinationLabelBehavior.alwaysHide,
-                destinations: controller.items
-                    .map(
-                      (item) => NavigationDestination(
-                        icon: Icon(item.iconData),
-                        label: item.title,
+          bottomNavigationBar: isLandscape
+              ? null
+              : DecoratedBox(
+                  decoration: BoxDecoration(
+                    color: semantic.body,
+                    border: Border(
+                      top: BorderSide(color: semantic.border),
+                    ),
+                  ),
+                  child: SafeArea(
+                    top: false,
+                    child: Obx(
+                      () => NavigationBar(
+                        backgroundColor: Colors.transparent,
+                        selectedIndex: controller.index.value,
+                        onDestinationSelected: controller.setIndex,
+                        height: 64,
+                        labelBehavior:
+                            NavigationDestinationLabelBehavior.alwaysShow,
+                        destinations: controller.items
+                            .map(
+                              (item) => NavigationDestination(
+                                icon: Icon(item.iconData),
+                                selectedIcon: Icon(
+                                  item.iconData,
+                                  color: theme.colorScheme.primary,
+                                ),
+                                tooltip: item.title,
+                                label: item.title,
+                              ),
+                            )
+                            .toList(),
                       ),
-                    )
-                    .toList(),
-              ),
-            ),
-          ),
+                    ),
+                  ),
+                ),
         );
       },
     );

--- a/simple_live_app/lib/modules/live_room/live_room_page.dart
+++ b/simple_live_app/lib/modules/live_room/live_room_page.dart
@@ -8,6 +8,8 @@ import 'package:media_kit_video/media_kit_video.dart';
 import 'package:remixicon/remixicon.dart';
 import 'package:simple_live_app/app/app_style.dart';
 import 'package:simple_live_app/app/controller/app_settings_controller.dart';
+import 'package:simple_live_app/app/design_system/app_design_tokens.dart';
+import 'package:simple_live_app/app/design_system/app_theme_extension.dart';
 import 'package:simple_live_app/app/sites.dart';
 import 'package:simple_live_app/app/utils.dart';
 import 'package:simple_live_app/modules/live_room/live_room_controller.dart';
@@ -32,58 +34,7 @@ class LiveRoomPage extends GetView<LiveRoomController> {
     final page = Obx(
       () {
         if (controller.loadError.value) {
-          return Scaffold(
-            appBar: AppBar(
-              title: const Text("直播间加载失败"),
-            ),
-            body: Padding(
-              padding: AppStyle.edgeInsetsA12,
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.stretch,
-                mainAxisAlignment: MainAxisAlignment.center,
-                children: [
-                  LottieBuilder.asset(
-                    'assets/lotties/error.json',
-                    height: 140,
-                    repeat: false,
-                  ),
-                  const Text(
-                    "直播间加载失败",
-                    textAlign: TextAlign.center,
-                  ),
-                  AppStyle.vGap4,
-                  Text(
-                    controller.error?.toString() ?? "未知错误",
-                    textAlign: TextAlign.center,
-                    maxLines: 1,
-                    overflow: TextOverflow.ellipsis,
-                    style: const TextStyle(fontSize: 12, color: Colors.grey),
-                  ),
-                  AppStyle.vGap4,
-                  Text(
-                    "${controller.rxSite.value.id} - ${controller.rxRoomId.value}",
-                    textAlign: TextAlign.center,
-                    style: const TextStyle(fontSize: 12, color: Colors.grey),
-                  ),
-                  Row(
-                    mainAxisAlignment: MainAxisAlignment.center,
-                    children: [
-                      TextButton.icon(
-                        onPressed: controller.copyErrorDetail,
-                        icon: const Icon(Remix.file_copy_line),
-                        label: const Text("复制信息"),
-                      ),
-                      TextButton.icon(
-                        onPressed: controller.refreshRoom,
-                        icon: const Icon(Remix.refresh_line),
-                        label: const Text("刷新"),
-                      ),
-                    ],
-                  )
-                ],
-              ),
-            ),
-          );
+          return _buildLoadErrorPage(context);
         }
         if (controller.fullScreenState.value) {
           return PopScope(
@@ -110,13 +61,129 @@ class LiveRoomPage extends GetView<LiveRoomController> {
     );
   }
 
+  Widget _buildLoadErrorPage(BuildContext context) {
+    final semantic = context.appTheme;
+    final theme = Theme.of(context);
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text("直播间加载失败"),
+      ),
+      body: SafeArea(
+        child: Center(
+          child: SingleChildScrollView(
+            padding: AppStyle.edgeInsetsA16,
+            child: ConstrainedBox(
+              constraints: const BoxConstraints(maxWidth: 420),
+              child: DecoratedBox(
+                decoration: BoxDecoration(
+                  color: semantic.elevatedSurface,
+                  borderRadius:
+                      BorderRadius.circular(AppDesignTokens.radius16),
+                  border: Border.all(color: semantic.border),
+                  boxShadow: [
+                    BoxShadow(
+                      color: semantic.shadow,
+                      blurRadius: 16,
+                      offset: const Offset(0, 6),
+                    ),
+                  ],
+                ),
+                child: Padding(
+                  padding: AppStyle.edgeInsetsA24,
+                  child: Column(
+                    mainAxisSize: MainAxisSize.min,
+                    crossAxisAlignment: CrossAxisAlignment.stretch,
+                    children: [
+                      ExcludeSemantics(
+                        child: LottieBuilder.asset(
+                          'assets/lotties/error.json',
+                          height: 120,
+                          repeat: false,
+                          animate: !MediaQuery.of(context).disableAnimations,
+                        ),
+                      ),
+                      AppStyle.vGap12,
+                      Text(
+                        "直播间加载失败",
+                        textAlign: TextAlign.center,
+                        style: theme.textTheme.titleMedium?.copyWith(
+                          color: semantic.textPrimary,
+                          fontWeight: FontWeight.w700,
+                        ),
+                      ),
+                      AppStyle.vGap8,
+                      Text(
+                        controller.error?.toString() ?? "未知错误",
+                        textAlign: TextAlign.center,
+                        maxLines: 3,
+                        overflow: TextOverflow.ellipsis,
+                        style: theme.textTheme.bodySmall?.copyWith(
+                          color: semantic.textSecondary,
+                        ),
+                      ),
+                      AppStyle.vGap12,
+                      Center(
+                        child: Container(
+                          padding: const EdgeInsets.symmetric(
+                            horizontal: AppDesignTokens.space12,
+                            vertical: AppDesignTokens.space8,
+                          ),
+                          decoration: BoxDecoration(
+                            color: semantic.secondarySurface,
+                            borderRadius: BorderRadius.circular(999),
+                            border: Border.all(color: semantic.border),
+                          ),
+                          child: Text(
+                            "${controller.rxSite.value.id} - ${controller.rxRoomId.value}",
+                            maxLines: 1,
+                            overflow: TextOverflow.ellipsis,
+                            style: theme.textTheme.labelMedium?.copyWith(
+                              color: semantic.textSecondary,
+                            ),
+                          ),
+                        ),
+                      ),
+                      AppStyle.vGap16,
+                      Wrap(
+                        alignment: WrapAlignment.center,
+                        spacing: AppDesignTokens.space8,
+                        runSpacing: AppDesignTokens.space8,
+                        children: [
+                          OutlinedButton.icon(
+                            onPressed: controller.copyErrorDetail,
+                            icon: const Icon(Remix.file_copy_line, size: 18),
+                            label: const Text("复制信息"),
+                          ),
+                          FilledButton.icon(
+                            onPressed: controller.refreshRoom,
+                            icon: const Icon(Remix.refresh_line, size: 18),
+                            label: const Text("刷新"),
+                          ),
+                        ],
+                      )
+                    ],
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
   Widget buildPageUI() {
     return OrientationBuilder(
       builder: (context, orientation) {
         return Scaffold(
           appBar: AppBar(
             title: Obx(
-              () => Text(controller.detail.value?.title ?? "直播间"),
+              () => Text(
+                controller.detail.value?.title ?? "直播间",
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+              ),
             ),
             actions: buildAppbarActions(context),
           ),
@@ -143,97 +210,94 @@ class LiveRoomPage extends GetView<LiveRoomController> {
   }
 
   Widget buildTabletUI(BuildContext context) {
+    final semantic = context.appTheme;
     return Column(
       children: [
         Expanded(
           child: Row(
             children: [
               Expanded(
+                flex: 3,
                 child: buildMediaPlayer(),
               ),
-              SizedBox(
-                width: 300,
-                child: Column(
-                  children: [
-                    buildUserProfile(context),
-                    buildMessageArea(),
-                  ],
+              Flexible(
+                flex: 2,
+                child: ConstrainedBox(
+                  constraints: const BoxConstraints(maxWidth: 380),
+                  child: Column(
+                    children: [
+                      buildUserProfile(context),
+                      buildMessageArea(),
+                    ],
+                  ),
                 ),
               ),
             ],
           ),
         ),
-        Container(
-          decoration: BoxDecoration(
-            color: Theme.of(context).cardColor,
-            border: Border(
-              top: BorderSide(
-                color: Colors.grey.withAlpha(25),
+        SafeArea(
+          top: false,
+          child: Container(
+            decoration: BoxDecoration(
+              color: semantic.elevatedSurface,
+              border: Border(
+                top: BorderSide(color: semantic.border),
+              ),
+            ),
+            padding: const EdgeInsets.symmetric(
+              horizontal: AppDesignTokens.space12,
+              vertical: AppDesignTokens.space8,
+            ),
+            child: SingleChildScrollView(
+              scrollDirection: Axis.horizontal,
+              child: Row(
+                children: [
+                  _buildBottomAction(
+                    context,
+                    onPressed: controller.refreshRoom,
+                    icon: Remix.refresh_line,
+                    label: "刷新",
+                  ),
+                  AppStyle.hGap8,
+                  Obx(
+                    () => _buildBottomAction(
+                      context,
+                      onPressed: controller.followed.value
+                          ? controller.removeFollowUser
+                          : controller.followUser,
+                      icon: controller.followed.value
+                          ? Remix.heart_fill
+                          : Remix.heart_line,
+                      label: controller.followed.value ? "取消关注" : "关注",
+                      emphasized: !controller.followed.value,
+                    ),
+                  ),
+                  AppStyle.hGap24,
+                  _buildBottomAction(
+                    context,
+                    onPressed: controller.share,
+                    icon: Remix.share_line,
+                    label: "分享",
+                  ),
+                  AppStyle.hGap8,
+                  (Platform.isWindows || Platform.isLinux)
+                      ? _buildBottomAction(
+                          context,
+                          onPressed: controller.visitWebLive,
+                          icon: Remix.chrome_fill,
+                          label: "浏览器打开",
+                        )
+                      : _buildBottomAction(
+                          context,
+                          onPressed: controller.copyUrl,
+                          icon: Remix.file_copy_line,
+                          label: "复制链接",
+                        ),
+                ],
               ),
             ),
           ),
-          padding: AppStyle.edgeInsetsV4.copyWith(
-            bottom: AppStyle.bottomBarHeight + 4,
-          ),
-          child: Row(
-            children: [
-              TextButton.icon(
-                style: TextButton.styleFrom(
-                  textStyle: const TextStyle(fontSize: 14),
-                ),
-                onPressed: controller.refreshRoom,
-                icon: const Icon(Remix.refresh_line),
-                label: const Text("刷新"),
-              ),
-              Obx(
-                () => controller.followed.value
-                    ? TextButton.icon(
-                        style: TextButton.styleFrom(
-                          textStyle: const TextStyle(fontSize: 14),
-                        ),
-                        onPressed: controller.removeFollowUser,
-                        icon: const Icon(Remix.heart_fill),
-                        label: const Text("取消关注"),
-                      )
-                    : TextButton.icon(
-                        style: TextButton.styleFrom(
-                          textStyle: const TextStyle(fontSize: 14),
-                        ),
-                        onPressed: controller.followUser,
-                        icon: const Icon(Remix.heart_line),
-                        label: const Text("关注"),
-                      ),
-              ),
-              const Expanded(child: Center()),
-              TextButton.icon(
-                style: TextButton.styleFrom(
-                  textStyle: const TextStyle(fontSize: 14),
-                ),
-                onPressed: controller.share,
-                icon: const Icon(Remix.share_line),
-                label: const Text("分享"),
-              ),
-              (Platform.isWindows || Platform.isLinux)
-                  ? TextButton.icon(
-                      style: TextButton.styleFrom(
-                        textStyle: const TextStyle(fontSize: 14),
-                      ),
-                      onPressed: controller.visitWebLive,
-                      icon: const Icon(Remix.chrome_fill),
-                      label: const Text("浏览器打开"),
-                    )
-                  : TextButton.icon(
-                      style: TextButton.styleFrom(
-                        textStyle: const TextStyle(fontSize: 14),
-                      ),
-                      onPressed: controller.copyUrl,
-                      icon: const Icon(Remix.file_copy_line),
-                      label: const Text("复制链接"),
-                    ),
-            ],
-          ),
         ),
-        //buildBottomActions(context),
       ],
     );
   }
@@ -287,227 +351,177 @@ class LiveRoomPage extends GetView<LiveRoomController> {
   }
 
   Widget buildUserProfile(BuildContext context) {
-    return Container(
-      decoration: BoxDecoration(
-        color: Theme.of(context).cardColor,
-        border: Border(
-          top: BorderSide(
-            color: Colors.grey.withAlpha(25),
-          ),
-          bottom: BorderSide(
-            color: Colors.grey.withAlpha(25),
-          ),
-        ),
+    final semantic = context.appTheme;
+    final theme = Theme.of(context);
+
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(
+        AppDesignTokens.space12,
+        AppDesignTokens.space12,
+        AppDesignTokens.space12,
+        AppDesignTokens.space8,
       ),
-      padding: AppStyle.edgeInsetsA8.copyWith(
-        left: 12,
-        right: 12,
-      ),
-      child: Obx(
-        () => Row(
-          mainAxisAlignment: MainAxisAlignment.start,
-          children: [
-            Container(
-              decoration: BoxDecoration(
-                border: Border.all(color: Colors.grey.withAlpha(50)),
-                borderRadius: AppStyle.radius24,
-              ),
-              child: NetImage(
-                controller.detail.value?.userAvatar ?? "",
-                width: 48,
-                height: 48,
-                borderRadius: 24,
-              ),
+      child: DecoratedBox(
+        decoration: BoxDecoration(
+          color: semantic.elevatedSurface,
+          borderRadius: BorderRadius.circular(AppDesignTokens.radius16),
+          border: Border.all(color: semantic.border),
+          boxShadow: [
+            BoxShadow(
+              color: semantic.shadow,
+              blurRadius: 12,
+              offset: const Offset(0, 4),
             ),
-            AppStyle.hGap12,
-            Expanded(
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Text(
-                    controller.detail.value?.userName ?? "",
-                    maxLines: 1,
-                    overflow: TextOverflow.ellipsis,
+          ],
+        ),
+        child: Padding(
+          padding: AppStyle.edgeInsetsA12,
+          child: Obx(
+            () => Row(
+              mainAxisAlignment: MainAxisAlignment.start,
+              children: [
+                Container(
+                  decoration: BoxDecoration(
+                    border: Border.all(color: semantic.border),
+                    borderRadius: AppStyle.radius24,
                   ),
-                  AppStyle.vGap4,
-                  Row(
+                  child: NetImage(
+                    controller.detail.value?.userAvatar ?? "",
+                    width: 48,
+                    height: 48,
+                    borderRadius: 24,
+                  ),
+                ),
+                AppStyle.hGap12,
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
                     children: [
-                      Image.asset(
-                        controller.site.logo,
-                        width: 20,
+                      Text(
+                        controller.detail.value?.userName ?? "",
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                        style: theme.textTheme.titleSmall?.copyWith(
+                          color: semantic.textPrimary,
+                          fontWeight: FontWeight.w700,
+                        ),
+                      ),
+                      AppStyle.vGap4,
+                      Row(
+                        children: [
+                          Image.asset(
+                            controller.site.logo,
+                            width: 18,
+                            height: 18,
+                          ),
+                          AppStyle.hGap4,
+                          Flexible(
+                            child: Text(
+                              controller.site.name,
+                              maxLines: 1,
+                              overflow: TextOverflow.ellipsis,
+                              style: theme.textTheme.bodySmall?.copyWith(
+                                color: semantic.textSecondary,
+                              ),
+                            ),
+                          ),
+                        ],
+                      ),
+                    ],
+                  ),
+                ),
+                AppStyle.hGap8,
+                Container(
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: AppDesignTokens.space8,
+                    vertical: AppDesignTokens.space4,
+                  ),
+                  decoration: BoxDecoration(
+                    color: theme.colorScheme.primary.withAlpha(18),
+                    borderRadius: BorderRadius.circular(999),
+                    border: Border.all(
+                      color: theme.colorScheme.primary.withAlpha(44),
+                    ),
+                  ),
+                  child: Row(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      Icon(
+                        Remix.fire_fill,
+                        size: 16,
+                        color: theme.colorScheme.primary,
                       ),
                       AppStyle.hGap4,
                       Text(
-                        controller.site.name,
-                        style: const TextStyle(
-                          fontSize: 12,
-                          color: Colors.grey,
+                        Utils.onlineToString(
+                          controller.detail.value?.online ?? 0,
+                        ),
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                        style: theme.textTheme.labelMedium?.copyWith(
+                          color: semantic.textPrimary,
+                          fontWeight: FontWeight.w700,
                         ),
                       ),
                     ],
                   ),
-                ],
-              ),
-            ),
-            AppStyle.hGap12,
-            Row(
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                const Icon(
-                  Remix.fire_fill,
-                  size: 20,
-                  color: Colors.orange,
-                ),
-                AppStyle.hGap4,
-                Text(
-                  Utils.onlineToString(
-                    controller.detail.value?.online ?? 0,
-                  ),
-                  style: const TextStyle(fontSize: 14),
                 ),
               ],
             ),
-          ],
+          ),
         ),
       ),
     );
   }
 
   Widget buildBottomActions(BuildContext context) {
-    return Container(
-      decoration: BoxDecoration(
-        color: Theme.of(context).cardColor,
-        border: Border(
-          top: BorderSide(
-            color: Colors.grey.withAlpha(25),
+    final semantic = context.appTheme;
+    return SafeArea(
+      top: false,
+      child: Container(
+        decoration: BoxDecoration(
+          color: semantic.elevatedSurface,
+          border: Border(
+            top: BorderSide(color: semantic.border),
           ),
         ),
-      ),
-      padding: EdgeInsets.only(bottom: AppStyle.bottomBarHeight),
-      child: Row(
-        children: [
-          Expanded(
-            child: Obx(
-              () => controller.followed.value
-                  ? TextButton.icon(
-                      style: TextButton.styleFrom(
-                        textStyle: const TextStyle(fontSize: 14),
-                      ),
-                      onPressed: controller.removeFollowUser,
-                      icon: const Icon(Remix.heart_fill),
-                      label: const Text("取消关注"),
-                    )
-                  : TextButton.icon(
-                      style: TextButton.styleFrom(
-                        textStyle: const TextStyle(fontSize: 14),
-                      ),
-                      onPressed: controller.followUser,
-                      icon: const Icon(Remix.heart_line),
-                      label: const Text("关注"),
-                    ),
-            ),
-          ),
-          Expanded(
-            child: TextButton.icon(
-              style: TextButton.styleFrom(
-                textStyle: const TextStyle(fontSize: 14),
-              ),
-              onPressed: controller.refreshRoom,
-              icon: const Icon(Remix.refresh_line),
-              label: const Text("刷新"),
-            ),
-          ),
-          Expanded(
-            child: TextButton.icon(
-              style: TextButton.styleFrom(
-                textStyle: const TextStyle(fontSize: 14),
-              ),
-              onPressed: controller.share,
-              icon: const Icon(Remix.share_line),
-              label: const Text("分享"),
-            ),
-          ),
-        ],
-      ),
-    );
-  }
-
-  Widget buildMessageArea() {
-    return Expanded(
-      child: DefaultTabController(
-        length: 4,
-        child: Column(
+        padding: const EdgeInsets.symmetric(
+          horizontal: AppDesignTokens.space12,
+          vertical: AppDesignTokens.space8,
+        ),
+        child: Row(
           children: [
-            TabBar(
-              indicatorSize: TabBarIndicatorSize.tab,
-              labelPadding: EdgeInsets.zero,
-              indicatorWeight: 1.0,
-              tabs: [
-                const Tab(
-                  text: "聊天",
-                ),
-                Tab(
-                  child: Obx(
-                    () => Text(
-                      controller.superChats.isNotEmpty
-                          ? "SC(${controller.superChats.length})"
-                          : "SC",
-                    ),
-                  ),
-                ),
-                const Tab(
-                  text: "关注",
-                ),
-                const Tab(
-                  text: "设置",
-                ),
-              ],
-            ),
             Expanded(
-              child: TabBarView(
-                children: [
-                  Obx(
-                    () => Stack(
-                      children: [
-                        ListView.separated(
-                          controller: controller.scrollController,
-                          separatorBuilder: (_, i) => Obx(
-                            () => SizedBox(
-                              // *2与原来的EdgeInsets.symmetric(vertical: )做兼容
-                              height: AppSettingsController
-                                      .instance.chatTextGap.value *
-                                  2,
-                            ),
-                          ),
-                          padding: AppStyle.edgeInsetsA12,
-                          itemCount: controller.messages.length,
-                          itemBuilder: (_, i) {
-                            var item = controller.messages[i];
-                            return buildMessageItem(item);
-                          },
-                        ),
-                        Visibility(
-                          visible: controller.disableAutoScroll.value,
-                          child: Positioned(
-                            right: 12,
-                            bottom: 12,
-                            child: ElevatedButton.icon(
-                              onPressed: () {
-                                controller.disableAutoScroll.value = false;
-                                controller.chatScrollToBottom();
-                              },
-                              icon: const Icon(Icons.expand_more),
-                              label: const Text("最新"),
-                            ),
-                          ),
-                        ),
-                      ],
-                    ),
-                  ),
-                  buildSuperChats(),
-                  buildFollowList(),
-                  buildSettings(),
-                ],
+              child: Obx(
+                () => _buildBottomAction(
+                  context,
+                  onPressed: controller.followed.value
+                      ? controller.removeFollowUser
+                      : controller.followUser,
+                  icon: controller.followed.value
+                      ? Remix.heart_fill
+                      : Remix.heart_line,
+                  label: controller.followed.value ? "取消关注" : "关注",
+                  emphasized: !controller.followed.value,
+                ),
+              ),
+            ),
+            AppStyle.hGap8,
+            Expanded(
+              child: _buildBottomAction(
+                context,
+                onPressed: controller.refreshRoom,
+                icon: Remix.refresh_line,
+                label: "刷新",
+              ),
+            ),
+            AppStyle.hGap8,
+            Expanded(
+              child: _buildBottomAction(
+                context,
+                onPressed: controller.share,
+                icon: Remix.share_line,
+                label: "分享",
               ),
             ),
           ],
@@ -516,79 +530,214 @@ class LiveRoomPage extends GetView<LiveRoomController> {
     );
   }
 
-  Widget buildMessageItem(LiveMessage message) {
+  Widget buildMessageArea() {
+    return Expanded(
+      child: Padding(
+        padding: const EdgeInsets.fromLTRB(
+          AppDesignTokens.space12,
+          0,
+          AppDesignTokens.space12,
+          AppDesignTokens.space8,
+        ),
+        child: Builder(
+          builder: (context) {
+            final semantic = context.appTheme;
+            final theme = Theme.of(context);
+            return Material(
+              color: semantic.elevatedSurface,
+              surfaceTintColor: Colors.transparent,
+              clipBehavior: Clip.antiAlias,
+              shape: RoundedRectangleBorder(
+                borderRadius: BorderRadius.circular(AppDesignTokens.radius16),
+                side: BorderSide(color: semantic.border),
+              ),
+              child: DefaultTabController(
+                length: 4,
+                child: Column(
+                  children: [
+                    Container(
+                      color: semantic.secondarySurface,
+                      padding: const EdgeInsets.fromLTRB(8, 8, 8, 0),
+                      child: TabBar(
+                        indicatorSize: TabBarIndicatorSize.tab,
+                        labelPadding: EdgeInsets.zero,
+                        dividerColor: Colors.transparent,
+                        indicator: BoxDecoration(
+                          color: theme.colorScheme.primaryContainer,
+                          borderRadius: BorderRadius.circular(
+                            AppDesignTokens.radius12,
+                          ),
+                        ),
+                        labelColor: theme.colorScheme.onPrimaryContainer,
+                        unselectedLabelColor: semantic.textSecondary,
+                        tabs: [
+                          const Tab(text: "聊天"),
+                          Tab(
+                            child: Obx(
+                              () => Text(
+                                controller.superChats.isNotEmpty
+                                    ? "SC(${controller.superChats.length})"
+                                    : "SC",
+                                maxLines: 1,
+                                overflow: TextOverflow.ellipsis,
+                              ),
+                            ),
+                          ),
+                          const Tab(text: "关注"),
+                          const Tab(text: "设置"),
+                        ],
+                      ),
+                    ),
+                    Expanded(
+                      child: TabBarView(
+                        children: [
+                          Obx(
+                            () => Stack(
+                              children: [
+                                ListView.separated(
+                                  controller: controller.scrollController,
+                                  separatorBuilder: (_, i) => Obx(
+                                    () => SizedBox(
+                                      // *2与原来的EdgeInsets.symmetric(vertical: )做兼容
+                                      height: AppSettingsController
+                                              .instance.chatTextGap.value *
+                                          2,
+                                    ),
+                                  ),
+                                  padding: AppStyle.edgeInsetsA12,
+                                  itemCount: controller.messages.length,
+                                  itemBuilder: (context, i) {
+                                    var item = controller.messages[i];
+                                    return buildMessageItem(context, item);
+                                  },
+                                ),
+                                if (controller.disableAutoScroll.value)
+                                  Positioned(
+                                    right: 12,
+                                    bottom: 12,
+                                    child: FilledButton.tonalIcon(
+                                      onPressed: () {
+                                        controller.disableAutoScroll.value = false;
+                                        controller.chatScrollToBottom();
+                                      },
+                                      icon: const Icon(Icons.expand_more),
+                                      label: const Text("最新"),
+                                    ),
+                                  ),
+                              ],
+                            ),
+                          ),
+                          buildSuperChats(),
+                          buildFollowList(),
+                          buildSettings(),
+                        ],
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            );
+          },
+        ),
+      ),
+    );
+  }
+
+  Widget buildMessageItem(BuildContext context, LiveMessage message) {
+    final semantic = context.appTheme;
+    final theme = Theme.of(context);
+
     if (message.userName == "LiveSysMessage") {
       return Obx(
-        () => SelectableText(
-          message.message,
-          style: TextStyle(
-            color: Colors.grey,
-            fontSize: AppSettingsController.instance.chatTextSize.value,
+        () => Align(
+          alignment: Alignment.centerLeft,
+          child: Container(
+            padding: const EdgeInsets.symmetric(
+              horizontal: AppDesignTokens.space12,
+              vertical: AppDesignTokens.space8,
+            ),
+            decoration: BoxDecoration(
+              color: semantic.secondarySurface,
+              borderRadius: BorderRadius.circular(AppDesignTokens.radius12),
+              border: Border.all(color: semantic.border),
+            ),
+            child: SelectableText(
+              message.message,
+              style: theme.textTheme.bodySmall?.copyWith(
+                color: semantic.textTertiary,
+                fontSize: AppSettingsController.instance.chatTextSize.value,
+              ),
+            ),
           ),
         ),
       );
     }
 
     return Obx(
-      () => AppSettingsController.instance.chatBubbleStyle.value
-          ? Row(
-              mainAxisAlignment: MainAxisAlignment.start,
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Flexible(
-                  child: Container(
-                    decoration: BoxDecoration(
-                      color: Colors.blueGrey.withAlpha(25),
-                      //borderRadius: AppStyle.radius8,
-                      borderRadius: const BorderRadius.only(
-                        topRight: Radius.circular(12),
-                        bottomLeft: Radius.circular(12),
-                        bottomRight: Radius.circular(12),
-                      ),
+      () {
+        final userStyle = theme.textTheme.bodyMedium?.copyWith(
+          color: semantic.textSecondary,
+          fontSize: AppSettingsController.instance.chatTextSize.value,
+          fontWeight: FontWeight.w600,
+        );
+        final messageStyle = theme.textTheme.bodyMedium?.copyWith(
+          color: semantic.textPrimary,
+          fontSize: AppSettingsController.instance.chatTextSize.value,
+        );
+
+        if (AppSettingsController.instance.chatBubbleStyle.value) {
+          return Row(
+            mainAxisAlignment: MainAxisAlignment.start,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Flexible(
+                child: Container(
+                  decoration: BoxDecoration(
+                    color: theme.colorScheme.primary.withAlpha(16),
+                    borderRadius: const BorderRadius.only(
+                      topRight: Radius.circular(AppDesignTokens.radius12),
+                      bottomLeft: Radius.circular(AppDesignTokens.radius12),
+                      bottomRight: Radius.circular(AppDesignTokens.radius12),
                     ),
-                    padding:
-                        AppStyle.edgeInsetsA4.copyWith(left: 12, right: 12),
-                    child: SelectableText.rich(
-                      TextSpan(
-                        text: "${message.userName}：",
-                        style: TextStyle(
-                          color: Colors.grey,
-                          fontSize:
-                              AppSettingsController.instance.chatTextSize.value,
-                        ),
-                        children: [
-                          TextSpan(
-                            text: message.message,
-                            style: TextStyle(
-                              color: Get.isDarkMode
-                                  ? Colors.white
-                                  : AppColors.black333,
-                            ),
-                          )
-                        ],
-                      ),
+                    border: Border.all(
+                      color: theme.colorScheme.primary.withAlpha(34),
+                    ),
+                  ),
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: AppDesignTokens.space12,
+                    vertical: AppDesignTokens.space8,
+                  ),
+                  child: SelectableText.rich(
+                    TextSpan(
+                      text: "${message.userName}：",
+                      style: userStyle,
+                      children: [
+                        TextSpan(
+                          text: message.message,
+                          style: messageStyle,
+                        )
+                      ],
                     ),
                   ),
                 ),
-              ],
-            )
-          : SelectableText.rich(
-              TextSpan(
-                text: "${message.userName}：",
-                style: TextStyle(
-                  color: Colors.grey,
-                  fontSize: AppSettingsController.instance.chatTextSize.value,
-                ),
-                children: [
-                  TextSpan(
-                    text: message.message,
-                    style: TextStyle(
-                      color: Get.isDarkMode ? Colors.white : AppColors.black333,
-                    ),
-                  )
-                ],
               ),
-            ),
+            ],
+          );
+        }
+
+        return SelectableText.rich(
+          TextSpan(
+            text: "${message.userName}：",
+            style: userStyle,
+            children: [
+              TextSpan(
+                text: message.message,
+                style: messageStyle,
+              )
+            ],
+          ),
+        );
+      },
     );
   }
 
@@ -611,103 +760,119 @@ class LiveRoomPage extends GetView<LiveRoomController> {
   }
 
   Widget buildSettings() {
-    return ListView(
-      padding: AppStyle.edgeInsetsA12,
-      children: [
-        Obx(
-          () => Visibility(
-            visible: controller.autoExitEnable.value,
-            child: ListTile(
-              leading: const Icon(Icons.timer_outlined),
-              visualDensity: VisualDensity.compact,
-              title: Text("${parseDuration(controller.countdown.value)}后自动关闭"),
+    return Builder(
+      builder: (context) {
+        final semantic = context.appTheme;
+        final theme = Theme.of(context);
+        return ListView(
+          padding: AppStyle.edgeInsetsA12,
+          children: [
+            Obx(
+              () => Visibility(
+                visible: controller.autoExitEnable.value,
+                child: Padding(
+                  padding: AppStyle.edgeInsetsB12,
+                  child: SettingsCard(
+                    child: ListTile(
+                      leading: Icon(
+                        Icons.timer_outlined,
+                        color: theme.colorScheme.primary,
+                      ),
+                      visualDensity: VisualDensity.compact,
+                      title: Text(
+                        "${parseDuration(controller.countdown.value)}后自动关闭",
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                      ),
+                    ),
+                  ),
+                ),
+              ),
             ),
-          ),
-        ),
-        Padding(
-          padding: AppStyle.edgeInsetsA12,
-          child: Text(
-            "聊天区",
-            style: Get.textTheme.titleSmall,
-          ),
-        ),
-        SettingsCard(
-          child: Column(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              Obx(
-                () => SettingsNumber(
-                  title: "文字大小",
-                  value:
-                      AppSettingsController.instance.chatTextSize.value.toInt(),
-                  min: 8,
-                  max: 36,
-                  onChanged: (e) {
-                    AppSettingsController.instance
-                        .setChatTextSize(e.toDouble());
-                  },
-                ),
+            _buildSectionHeader(context, "聊天区"),
+            SettingsCard(
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Obx(
+                    () => SettingsNumber(
+                      title: "文字大小",
+                      value: AppSettingsController.instance.chatTextSize.value
+                          .toInt(),
+                      min: 8,
+                      max: 36,
+                      onChanged: (e) {
+                        AppSettingsController.instance
+                            .setChatTextSize(e.toDouble());
+                      },
+                    ),
+                  ),
+                  AppStyle.divider,
+                  Obx(
+                    () => SettingsNumber(
+                      title: "上下间隔",
+                      value: AppSettingsController.instance.chatTextGap.value
+                          .toInt(),
+                      min: 0,
+                      max: 12,
+                      onChanged: (e) {
+                        AppSettingsController.instance
+                            .setChatTextGap(e.toDouble());
+                      },
+                    ),
+                  ),
+                  AppStyle.divider,
+                  Obx(
+                    () => SettingsSwitch(
+                      title: "气泡样式",
+                      value: AppSettingsController.instance.chatBubbleStyle.value,
+                      onChanged: (e) {
+                        AppSettingsController.instance.setChatBubbleStyle(e);
+                      },
+                    ),
+                  ),
+                ],
               ),
-              AppStyle.divider,
-              Obx(
-                () => SettingsNumber(
-                  title: "上下间隔",
-                  value:
-                      AppSettingsController.instance.chatTextGap.value.toInt(),
-                  min: 0,
-                  max: 12,
-                  onChanged: (e) {
-                    AppSettingsController.instance.setChatTextGap(e.toDouble());
-                  },
-                ),
+            ),
+            AppStyle.vGap12,
+            _buildSectionHeader(context, "更多设置"),
+            SettingsCard(
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  SettingsAction(
+                    title: "关键词屏蔽",
+                    onTap: controller.showDanmuShield,
+                  ),
+                  AppStyle.divider,
+                  SettingsAction(
+                    title: "弹幕设置",
+                    onTap: controller.showDanmuSettingsSheet,
+                  ),
+                  AppStyle.divider,
+                  SettingsAction(
+                    title: "定时关闭",
+                    onTap: controller.showAutoExitSheet,
+                  ),
+                  AppStyle.divider,
+                  SettingsAction(
+                    title: "画面尺寸",
+                    onTap: controller.showPlayerSettingsSheet,
+                  ),
+                ],
               ),
-              AppStyle.divider,
-              Obx(
-                () => SettingsSwitch(
-                  title: "气泡样式",
-                  value: AppSettingsController.instance.chatBubbleStyle.value,
-                  onChanged: (e) {
-                    AppSettingsController.instance.setChatBubbleStyle(e);
-                  },
-                ),
+            ),
+            AppStyle.vGap12,
+            Text(
+              "直播设置会立即生效",
+              textAlign: TextAlign.center,
+              style: theme.textTheme.labelSmall?.copyWith(
+                color: semantic.textTertiary,
               ),
-            ],
-          ),
-        ),
-        Padding(
-          padding: AppStyle.edgeInsetsA12,
-          child: Text(
-            "更多设置",
-            style: Get.textTheme.titleSmall,
-          ),
-        ),
-        SettingsCard(
-          child: Column(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              SettingsAction(
-                title: "关键词屏蔽",
-                onTap: controller.showDanmuShield,
-              ),
-              AppStyle.divider,
-              SettingsAction(
-                title: "弹幕设置",
-                onTap: controller.showDanmuSettingsSheet,
-              ),
-              AppStyle.divider,
-              SettingsAction(
-                title: "定时关闭",
-                onTap: controller.showAutoExitSheet,
-              ),
-              AppStyle.divider,
-              SettingsAction(
-                title: "画面尺寸",
-                onTap: controller.showPlayerSettingsSheet,
-              ),
-            ],
-          ),
-        ),
-      ],
+            ),
+          ],
+        );
+      },
     );
   }
 
@@ -718,6 +883,7 @@ class LiveRoomPage extends GetView<LiveRoomController> {
           RefreshIndicator(
             onRefresh: FollowService.instance.loadData,
             child: ListView.builder(
+              padding: AppStyle.edgeInsetsV8,
               itemCount: FollowService.instance.liveList.length,
               itemBuilder: (_, i) {
                 var item = FollowService.instance.liveList[i];
@@ -755,11 +921,15 @@ class LiveRoomPage extends GetView<LiveRoomController> {
 
   List<Widget> buildAppbarActions(BuildContext context) {
     return [
-      IconButton(
-        onPressed: () {
-          showMore();
-        },
-        icon: const Icon(Icons.more_horiz),
+      Padding(
+        padding: AppStyle.edgeInsetsR8,
+        child: IconButton.filledTonal(
+          tooltip: "更多",
+          onPressed: () {
+            showMore();
+          },
+          icon: const Icon(Icons.more_horiz),
+        ),
       ),
     ];
   }
@@ -770,116 +940,232 @@ class LiveRoomPage extends GetView<LiveRoomController> {
       constraints: const BoxConstraints(
         maxWidth: 600,
       ),
+      showDragHandle: true,
+      useSafeArea: true,
       isScrollControlled: true,
-      builder: (_) => Container(
-        padding: EdgeInsets.only(
-          bottom: AppStyle.bottomBarHeight,
-        ),
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            ListTile(
-              leading: const Icon(Icons.refresh),
-              title: const Text("刷新"),
-              trailing: const Icon(Icons.chevron_right),
-              onTap: () {
-                controller.refreshRoom();
-              },
-            ),
-            ListTile(
-              leading: const Icon(Icons.play_circle_outline),
-              trailing: const Icon(Icons.chevron_right),
-              title: const Text("切换清晰度"),
-              onTap: () {
-                Get.back();
-                controller.showQualitySheet();
-              },
-            ),
-            ListTile(
-              leading: const Icon(Icons.switch_video_outlined),
-              title: const Text("切换线路"),
-              trailing: const Icon(Icons.chevron_right),
-              onTap: () {
-                Get.back();
-                controller.showPlayUrlsSheet();
-              },
-            ),
-            ListTile(
-              leading: const Icon(Icons.aspect_ratio_outlined),
-              title: const Text("画面尺寸"),
-              trailing: const Icon(Icons.chevron_right),
-              onTap: () {
-                Get.back();
-                controller.showPlayerSettingsSheet();
-              },
-            ),
-            ListTile(
-              leading: const Icon(Icons.camera_alt_outlined),
-              title: const Text("截图"),
-              trailing: const Icon(Icons.chevron_right),
-              onTap: () {
-                controller.saveScreenshot();
-              },
-            ),
-            Visibility(
-              visible: Platform.isAndroid,
-              child: ListTile(
-                leading: const Icon(Icons.picture_in_picture),
-                title: const Text("小窗播放"),
-                trailing: const Icon(Icons.chevron_right),
+      builder: (context) => SafeArea(
+        top: false,
+        child: Padding(
+          padding: EdgeInsets.only(
+            left: AppDesignTokens.space12,
+            right: AppDesignTokens.space12,
+            bottom: AppStyle.bottomBarHeight + AppDesignTokens.space12,
+          ),
+          child: ListView(
+            shrinkWrap: true,
+            children: [
+              _buildMoreTile(
+                context,
+                icon: Icons.refresh,
+                title: "刷新",
                 onTap: () {
-                  Get.back();
-                  controller.enablePIP();
+                  controller.refreshRoom();
                 },
               ),
-            ),
-            ListTile(
-              leading: const Icon(Icons.timer_outlined),
-              title: const Text("定时关闭"),
-              trailing: const Icon(Icons.chevron_right),
-              onTap: () {
-                Get.back();
-                controller.showAutoExitSheet();
-              },
-            ),
-            ListTile(
-              leading: const Icon(Icons.share_sharp),
-              title: const Text("分享直播间"),
-              trailing: const Icon(Icons.chevron_right),
-              onTap: () {
-                Get.back();
-                controller.share();
-              },
-            ),
-            ListTile(
-              leading: const Icon(Icons.copy),
-              title: const Text("复制链接"),
-              trailing: const Icon(Icons.chevron_right),
-              onTap: () {
-                Get.back();
-                controller.copyUrl();
-              },
-            ),
-            ListTile(
-              leading: const Icon(Icons.open_in_new),
-              title: const Text("APP 中打开"),
-              trailing: const Icon(Icons.chevron_right),
-              onTap: () {
-                Get.back();
-                controller.openNaviteAPP();
-              },
-            ),
-            ListTile(
-              leading: const Icon(Icons.info_outline_rounded),
-              title: const Text("播放信息"),
-              trailing: const Icon(Icons.chevron_right),
-              onTap: () {
-                Get.back();
-                controller.showDebugInfo();
-              },
-            ),
-          ],
+              _buildMoreTile(
+                context,
+                icon: Icons.play_circle_outline,
+                title: "切换清晰度",
+                onTap: () {
+                  Get.back();
+                  controller.showQualitySheet();
+                },
+              ),
+              _buildMoreTile(
+                context,
+                icon: Icons.switch_video_outlined,
+                title: "切换线路",
+                onTap: () {
+                  Get.back();
+                  controller.showPlayUrlsSheet();
+                },
+              ),
+              _buildMoreTile(
+                context,
+                icon: Icons.aspect_ratio_outlined,
+                title: "画面尺寸",
+                onTap: () {
+                  Get.back();
+                  controller.showPlayerSettingsSheet();
+                },
+              ),
+              _buildMoreTile(
+                context,
+                icon: Icons.camera_alt_outlined,
+                title: "截图",
+                onTap: () {
+                  controller.saveScreenshot();
+                },
+              ),
+              Visibility(
+                visible: Platform.isAndroid,
+                child: _buildMoreTile(
+                  context,
+                  icon: Icons.picture_in_picture,
+                  title: "小窗播放",
+                  onTap: () {
+                    Get.back();
+                    controller.enablePIP();
+                  },
+                ),
+              ),
+              _buildMoreTile(
+                context,
+                icon: Icons.timer_outlined,
+                title: "定时关闭",
+                onTap: () {
+                  Get.back();
+                  controller.showAutoExitSheet();
+                },
+              ),
+              _buildMoreTile(
+                context,
+                icon: Icons.share_sharp,
+                title: "分享直播间",
+                onTap: () {
+                  Get.back();
+                  controller.share();
+                },
+              ),
+              _buildMoreTile(
+                context,
+                icon: Icons.copy,
+                title: "复制链接",
+                onTap: () {
+                  Get.back();
+                  controller.copyUrl();
+                },
+              ),
+              _buildMoreTile(
+                context,
+                icon: Icons.open_in_new,
+                title: "APP 中打开",
+                onTap: () {
+                  Get.back();
+                  controller.openNaviteAPP();
+                },
+              ),
+              _buildMoreTile(
+                context,
+                icon: Icons.info_outline_rounded,
+                title: "播放信息",
+                onTap: () {
+                  Get.back();
+                  controller.showDebugInfo();
+                },
+              ),
+            ],
+          ),
         ),
+      ),
+    );
+  }
+
+  Widget _buildBottomAction(
+    BuildContext context, {
+    required VoidCallback? onPressed,
+    required IconData icon,
+    required String label,
+    bool emphasized = false,
+  }) {
+    final semantic = context.appTheme;
+    final theme = Theme.of(context);
+    final foreground = emphasized
+        ? theme.colorScheme.onPrimaryContainer
+        : semantic.textPrimary;
+
+    return TextButton.icon(
+      style: TextButton.styleFrom(
+        minimumSize: const Size(0, 44),
+        padding: const EdgeInsets.symmetric(
+          horizontal: AppDesignTokens.space12,
+          vertical: AppDesignTokens.space8,
+        ),
+        foregroundColor: foreground,
+        backgroundColor: emphasized
+            ? theme.colorScheme.primaryContainer
+            : semantic.secondarySurface,
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(AppDesignTokens.radius12),
+          side: BorderSide(
+            color: emphasized
+                ? theme.colorScheme.primary.withAlpha(44)
+                : semantic.border,
+          ),
+        ),
+        textStyle: theme.textTheme.labelMedium?.copyWith(
+          color: foreground,
+          fontWeight: FontWeight.w700,
+        ),
+      ),
+      onPressed: onPressed,
+      icon: Icon(icon, size: 18),
+      label: Text(
+        label,
+        maxLines: 1,
+        overflow: TextOverflow.ellipsis,
+      ),
+    );
+  }
+
+  Widget _buildSectionHeader(BuildContext context, String title) {
+    final semantic = context.appTheme;
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(4, 4, 4, 8),
+      child: Text(
+        title,
+        style: Theme.of(context).textTheme.titleSmall?.copyWith(
+              color: semantic.textSecondary,
+              fontWeight: FontWeight.w700,
+            ),
+      ),
+    );
+  }
+
+  Widget _buildMoreTile(
+    BuildContext context, {
+    required IconData icon,
+    required String title,
+    required VoidCallback onTap,
+  }) {
+    final semantic = context.appTheme;
+    final theme = Theme.of(context);
+
+    return Padding(
+      padding: AppStyle.edgeInsetsV4,
+      child: ListTile(
+        contentPadding: const EdgeInsets.symmetric(
+          horizontal: AppDesignTokens.space12,
+          vertical: 2,
+        ),
+        leading: Container(
+          width: 36,
+          height: 36,
+          decoration: BoxDecoration(
+            color: semantic.secondarySurface,
+            borderRadius: BorderRadius.circular(AppDesignTokens.radius10),
+            border: Border.all(color: semantic.border),
+          ),
+          child: Icon(
+            icon,
+            size: 20,
+            color: theme.colorScheme.primary,
+          ),
+        ),
+        title: Text(
+          title,
+          maxLines: 1,
+          overflow: TextOverflow.ellipsis,
+          style: theme.textTheme.titleSmall?.copyWith(
+            color: semantic.textPrimary,
+            fontWeight: FontWeight.w600,
+          ),
+        ),
+        trailing: Icon(
+          Icons.chevron_right,
+          color: semantic.textTertiary,
+        ),
+        onTap: onTap,
       ),
     );
   }

--- a/simple_live_app/lib/modules/live_room/player/player_controls.dart
+++ b/simple_live_app/lib/modules/live_room/player/player_controls.dart
@@ -2,12 +2,12 @@ import 'dart:io';
 import 'package:canvas_danmaku/canvas_danmaku.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 import 'package:get/get.dart';
 import 'package:media_kit_video/media_kit_video.dart';
 import 'package:remixicon/remixicon.dart';
 import 'package:simple_live_app/app/app_style.dart';
 import 'package:simple_live_app/app/controller/app_settings_controller.dart';
+import 'package:simple_live_app/app/design_system/app_design_tokens.dart';
 import 'package:simple_live_app/app/sites.dart';
 import 'package:simple_live_app/app/utils.dart';
 import 'package:simple_live_app/modules/live_room/live_room_controller.dart';
@@ -56,10 +56,8 @@ Widget buildFullControls(
       children: [
         Container(),
         buildDanmuView(videoState, controller),
-
         Center(
-          child: // 中间
-              StreamBuilder(
+          child: StreamBuilder(
             stream: videoState.widget.controller.player.stream.buffering,
             initialData: videoState.widget.controller.player.state.buffering,
             builder: (_, s) => Visibility(
@@ -91,22 +89,10 @@ Widget buildFullControls(
                 width: double.infinity,
                 height: double.infinity,
                 color: Colors.transparent,
-                // child: Visibility(
-                //   //拖拽区域
-                //   visible: controller.smallWindowState.value,
-                //   child: DragToMoveArea(
-                //       child: Container(
-                //     width: double.infinity,
-                //     height: double.infinity,
-                //     color: Colors.transparent,
-                //   )),
-                // ),
               ),
             ),
           ),
         ),
-
-        // 顶部
         Obx(
           () => AnimatedPositioned(
             left: 0,
@@ -114,14 +100,14 @@ Widget buildFullControls(
             top: (controller.showControlsState.value &&
                     !controller.lockControlsState.value)
                 ? 0
-                : -(48 + padding.top),
+                : -(56 + padding.top),
             duration: const Duration(milliseconds: 200),
             child: Container(
-              height: 48 + padding.top,
               padding: EdgeInsets.only(
                 left: padding.left + 12,
                 right: padding.right + 12,
-                top: padding.top,
+                top: padding.top + 8,
+                bottom: 8,
               ),
               decoration: const BoxDecoration(
                 gradient: LinearGradient(
@@ -133,81 +119,66 @@ Widget buildFullControls(
                   ],
                 ),
               ),
-              child: Row(
-                children: [
-                  IconButton(
-                    onPressed: () {
-                      if (controller.smallWindowState.value) {
-                        controller.exitSmallWindow();
-                      } else {
-                        controller.exitFull();
-                      }
-                    },
-                    icon: const Icon(
-                      Icons.arrow_back,
-                      color: Colors.white,
-                      size: 24,
-                    ),
-                  ),
-                  AppStyle.hGap12,
-                  Expanded(
-                    child: Text(
-                      "${controller.detail.value?.title} - ${controller.detail.value?.userName}",
-                      maxLines: 1,
-                      overflow: TextOverflow.ellipsis,
-                      style: const TextStyle(color: Colors.white, fontSize: 16),
-                    ),
-                  ),
-                  AppStyle.hGap12,
-                  IconButton(
-                    onPressed: () {
-                      controller.saveScreenshot();
-                    },
-                    icon: const Icon(
-                      Icons.camera_alt_outlined,
-                      color: Colors.white,
-                      size: 24,
-                    ),
-                  ),
-                  IconButton(
-                    onPressed: () {
-                      showFollowUser(controller);
-                    },
-                    icon: const Icon(
-                      Remix.play_list_2_line,
-                      color: Colors.white,
-                      size: 24,
-                    ),
-                  ),
-                  Visibility(
-                    visible: Platform.isAndroid,
-                    child: IconButton(
+              child: _overlayControlsTheme(
+                child: Row(
+                  children: [
+                    IconButton(
                       onPressed: () {
-                        controller.enablePIP();
+                        if (controller.smallWindowState.value) {
+                          controller.exitSmallWindow();
+                        } else {
+                          controller.exitFull();
+                        }
                       },
-                      icon: const Icon(
-                        Icons.picture_in_picture,
-                        color: Colors.white,
-                        size: 24,
+                      icon: const Icon(Icons.arrow_back, size: 22),
+                    ),
+                    AppStyle.hGap12,
+                    Expanded(
+                      child: Text(
+                        "${controller.detail.value?.title} - ${controller.detail.value?.userName}",
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                        style: const TextStyle(
+                          color: Colors.white,
+                          fontSize: 16,
+                          fontWeight: FontWeight.w700,
+                        ),
                       ),
                     ),
-                  ),
-                  IconButton(
-                    onPressed: () {
-                      showPlayerSettings(controller);
-                    },
-                    icon: const Icon(
-                      Icons.more_horiz,
-                      color: Colors.white,
-                      size: 24,
+                    AppStyle.hGap12,
+                    IconButton(
+                      onPressed: () {
+                        controller.saveScreenshot();
+                      },
+                      icon: const Icon(Icons.camera_alt_outlined, size: 22),
                     ),
-                  ),
-                ],
+                    IconButton(
+                      onPressed: () {
+                        showFollowUser(controller);
+                      },
+                      icon: const Icon(Remix.play_list_2_line, size: 22),
+                    ),
+                    Visibility(
+                      visible: Platform.isAndroid,
+                      child: IconButton(
+                        onPressed: () {
+                          controller.enablePIP();
+                        },
+                        icon: const Icon(Icons.picture_in_picture, size: 22),
+                      ),
+                    ),
+                    IconButton(
+                      onPressed: () {
+                        showPlayerSettings(controller);
+                      },
+                      icon: const Icon(Icons.more_horiz, size: 22),
+                    ),
+                  ],
+                ),
               ),
             ),
           ),
         ),
-        // 底部
         Obx(
           () => AnimatedPositioned(
             left: 0,
@@ -215,7 +186,7 @@ Widget buildFullControls(
             bottom: (controller.showControlsState.value &&
                     !controller.lockControlsState.value)
                 ? 0
-                : -(80 + padding.bottom),
+                : -(88 + padding.bottom),
             duration: const Duration(milliseconds: 200),
             child: Container(
               decoration: const BoxDecoration(
@@ -231,119 +202,105 @@ Widget buildFullControls(
               padding: EdgeInsets.only(
                 left: padding.left + 12,
                 right: padding.right + 12,
-                bottom: padding.bottom,
+                bottom: padding.bottom + 8,
+                top: 24,
               ),
-              child: Row(
-                children: [
-                  IconButton(
-                    onPressed: () {
-                      controller.refreshRoom();
-                    },
-                    icon: const Icon(
-                      Remix.refresh_line,
-                      color: Colors.white,
-                    ),
-                  ),
-                  Offstage(
-                    offstage: controller.showDanmakuState.value,
-                    child: IconButton(
-                      onPressed: () => controller.showDanmakuState.value =
-                          !controller.showDanmakuState.value,
-                      icon: const ImageIcon(
-                        AssetImage('assets/icons/icon_danmaku_open.png'),
-                        size: 24,
-                        color: Colors.white,
-                      ),
-                    ),
-                  ),
-                  Offstage(
-                    offstage: !controller.showDanmakuState.value,
-                    child: IconButton(
-                      onPressed: () => controller.showDanmakuState.value =
-                          !controller.showDanmakuState.value,
-                      icon: const ImageIcon(
-                        AssetImage('assets/icons/icon_danmaku_close.png'),
-                        size: 24,
-                        color: Colors.white,
-                      ),
-                    ),
-                  ),
-                  IconButton(
-                    onPressed: () {
-                      showDanmakuSettings(controller);
-                    },
-                    icon: const ImageIcon(
-                      AssetImage('assets/icons/icon_danmaku_setting.png'),
-                      size: 24,
-                      color: Colors.white,
-                    ),
-                  ),
-                  const Expanded(child: Center()),
-                  Visibility(
-                    visible: !Platform.isAndroid && !Platform.isIOS,
-                    child: IconButton(
-                      key: volumeButtonkey,
+              child: _overlayControlsTheme(
+                child: Row(
+                  children: [
+                    IconButton(
                       onPressed: () {
-                        controller
-                            .showVolumeSlider(volumeButtonkey.currentContext!);
+                        controller.refreshRoom();
                       },
-                      icon: const Icon(
-                        Icons.volume_down,
-                        size: 24,
-                        color: Colors.white,
+                      icon: const Icon(Remix.refresh_line),
+                    ),
+                    Offstage(
+                      offstage: controller.showDanmakuState.value,
+                      child: IconButton(
+                        onPressed: () => controller.showDanmakuState.value =
+                            !controller.showDanmakuState.value,
+                        icon: const ImageIcon(
+                          AssetImage('assets/icons/icon_danmaku_open.png'),
+                          size: 22,
+                        ),
                       ),
                     ),
-                  ),
-                  TextButton(
-                    onPressed: () {
-                      showQualitesInfo(controller);
-                    },
-                    child: Obx(
-                      () => Text(
-                        controller.currentQualityInfo.value,
-                        style:
-                            const TextStyle(color: Colors.white, fontSize: 15),
+                    Offstage(
+                      offstage: !controller.showDanmakuState.value,
+                      child: IconButton(
+                        onPressed: () => controller.showDanmakuState.value =
+                            !controller.showDanmakuState.value,
+                        icon: const ImageIcon(
+                          AssetImage('assets/icons/icon_danmaku_close.png'),
+                          size: 22,
+                        ),
                       ),
                     ),
-                  ),
-                  TextButton(
-                    onPressed: () {
-                      showLinesInfo(controller);
-                    },
-                    child: Text(
-                      controller.currentLineInfo.value,
-                      style: const TextStyle(color: Colors.white, fontSize: 15),
+                    IconButton(
+                      onPressed: () {
+                        showDanmakuSettings(controller);
+                      },
+                      icon: const ImageIcon(
+                        AssetImage('assets/icons/icon_danmaku_setting.png'),
+                        size: 22,
+                      ),
                     ),
-                  ),
-                  IconButton(
-                    onPressed: () {
-                      controller.enterFullScreen();
-                    },
-                    icon: const Icon(
-                      Remix.fullscreen_line,
-                      color: Colors.white,
+                    const Expanded(child: Center()),
+                    Visibility(
+                      visible: !Platform.isAndroid && !Platform.isIOS,
+                      child: IconButton(
+                        key: volumeButtonkey,
+                        onPressed: () {
+                          controller
+                              .showVolumeSlider(volumeButtonkey.currentContext!);
+                        },
+                        icon: const Icon(Icons.volume_down, size: 22),
+                      ),
                     ),
-                  ),
-                  IconButton(
-                    onPressed: () {
-                      if (controller.smallWindowState.value) {
-                        controller.exitSmallWindow();
-                      } else {
-                        controller.exitFull();
-                      }
-                    },
-                    icon: const Icon(
-                      Remix.fullscreen_exit_fill,
-                      color: Colors.white,
+                    TextButton(
+                      onPressed: () {
+                        showQualitesInfo(controller);
+                      },
+                      child: Obx(
+                        () => Text(
+                          controller.currentQualityInfo.value,
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
+                        ),
+                      ),
                     ),
-                  ),
-                ],
+                    TextButton(
+                      onPressed: () {
+                        showLinesInfo(controller);
+                      },
+                      child: Text(
+                        controller.currentLineInfo.value,
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                      ),
+                    ),
+                    IconButton(
+                      onPressed: () {
+                        controller.enterFullScreen();
+                      },
+                      icon: const Icon(Remix.fullscreen_line),
+                    ),
+                    IconButton(
+                      onPressed: () {
+                        if (controller.smallWindowState.value) {
+                          controller.exitSmallWindow();
+                        } else {
+                          controller.exitFull();
+                        }
+                      },
+                      icon: const Icon(Remix.fullscreen_exit_fill),
+                    ),
+                  ],
+                ),
               ),
             ),
           ),
         ),
-
-        // 右侧锁定
         Obx(
           () => AnimatedPositioned(
             top: 0,
@@ -355,7 +312,6 @@ Widget buildFullControls(
             child: buildLockButton(controller),
           ),
         ),
-        // 左侧锁定
         Obx(
           () => AnimatedPositioned(
             top: 0,
@@ -367,24 +323,7 @@ Widget buildFullControls(
             child: buildLockButton(controller),
           ),
         ),
-        Obx(
-          () => Offstage(
-            offstage: !controller.showGestureTip.value,
-            child: Center(
-              child: Container(
-                padding: const EdgeInsets.all(12),
-                decoration: BoxDecoration(
-                  color: Colors.grey.shade900,
-                  borderRadius: BorderRadius.circular(12),
-                ),
-                child: Text(
-                  controller.gestureTipText.value,
-                  style: const TextStyle(fontSize: 18, color: Colors.white),
-                ),
-              ),
-            ),
-          ),
-        ),
+        _buildGestureTip(controller),
       ],
     ),
   );
@@ -398,11 +337,12 @@ Widget buildLockButton(LiveRoomController controller) {
       },
       child: Container(
         decoration: BoxDecoration(
-          color: Colors.black45,
-          borderRadius: AppStyle.radius8,
+          color: Colors.black.withAlpha(150),
+          borderRadius: BorderRadius.circular(AppDesignTokens.radius12),
+          border: Border.all(color: Colors.white.withAlpha(36)),
         ),
-        width: 40,
-        height: 40,
+        width: 44,
+        height: 44,
         child: Center(
           child: Icon(
             controller.lockControlsState.value
@@ -427,7 +367,6 @@ Widget buildControls(
     children: [
       Container(),
       buildDanmuView(videoState, controller),
-      // 中间
       Center(
         child: StreamBuilder(
           stream: videoState.widget.controller.player.stream.buffering,
@@ -447,7 +386,6 @@ Widget buildControls(
           onVerticalDragStart: controller.onVerticalDragStart,
           onVerticalDragUpdate: controller.onVerticalDragUpdate,
           onVerticalDragEnd: controller.onVerticalDragEnd,
-          //onLongPress: controller.showDebugInfo,
           child: MouseRegion(
             onEnter: controller.onEnter,
             child: Container(
@@ -462,7 +400,7 @@ Widget buildControls(
         () => AnimatedPositioned(
           left: 0,
           right: 0,
-          bottom: controller.showControlsState.value ? 0 : -48,
+          bottom: controller.showControlsState.value ? 0 : -56,
           duration: const Duration(milliseconds: 200),
           child: Container(
             decoration: const BoxDecoration(
@@ -475,141 +413,173 @@ Widget buildControls(
                 ],
               ),
             ),
-            child: Row(
-              children: [
-                IconButton(
-                  onPressed: () {
-                    controller.refreshRoom();
-                  },
-                  icon: const Icon(
-                    Remix.refresh_line,
-                    color: Colors.white,
-                  ),
-                ),
-                Offstage(
-                  offstage: controller.showDanmakuState.value,
-                  child: IconButton(
-                    onPressed: () => controller.showDanmakuState.value =
-                        !controller.showDanmakuState.value,
-                    icon: const ImageIcon(
-                      AssetImage('assets/icons/icon_danmaku_open.png'),
-                      size: 24,
-                      color: Colors.white,
-                    ),
-                  ),
-                ),
-                Offstage(
-                  offstage: !controller.showDanmakuState.value,
-                  child: IconButton(
-                    onPressed: () => controller.showDanmakuState.value =
-                        !controller.showDanmakuState.value,
-                    icon: const ImageIcon(
-                      AssetImage('assets/icons/icon_danmaku_close.png'),
-                      size: 24,
-                      color: Colors.white,
-                    ),
-                  ),
-                ),
-                IconButton(
-                  onPressed: () {
-                    controller.showDanmuSettingsSheet();
-                  },
-                  icon: const ImageIcon(
-                    AssetImage('assets/icons/icon_danmaku_setting.png'),
-                    size: 24,
-                    color: Colors.white,
-                  ),
-                ),
-                const Expanded(child: Center()),
-                Visibility(
-                  visible: !Platform.isAndroid && !Platform.isIOS,
-                  child: IconButton(
-                    key: volumeButtonkey,
+            padding: const EdgeInsets.fromLTRB(8, 18, 8, 8),
+            child: _overlayControlsTheme(
+              child: Row(
+                children: [
+                  IconButton(
                     onPressed: () {
-                      controller.showVolumeSlider(
-                        volumeButtonkey.currentContext!,
-                      );
+                      controller.refreshRoom();
                     },
-                    icon: const Icon(
-                      Icons.volume_down,
-                      size: 24,
-                      color: Colors.white,
-                    ),
+                    icon: const Icon(Remix.refresh_line),
                   ),
-                ),
-                Offstage(
-                  offstage: isPortrait,
-                  child: TextButton(
-                    onPressed: () {
-                      controller.showQualitySheet();
-                    },
-                    child: Obx(
-                      () => Text(
-                        controller.currentQualityInfo.value,
-                        style:
-                            const TextStyle(color: Colors.white, fontSize: 15),
+                  Offstage(
+                    offstage: controller.showDanmakuState.value,
+                    child: IconButton(
+                      onPressed: () => controller.showDanmakuState.value =
+                          !controller.showDanmakuState.value,
+                      icon: const ImageIcon(
+                        AssetImage('assets/icons/icon_danmaku_open.png'),
+                        size: 22,
                       ),
                     ),
                   ),
-                ),
-                Offstage(
-                  offstage: isPortrait,
-                  child: TextButton(
-                    onPressed: () {
-                      controller.showPlayUrlsSheet();
-                    },
-                    child: Text(
-                      controller.currentLineInfo.value,
-                      style: const TextStyle(color: Colors.white, fontSize: 15),
+                  Offstage(
+                    offstage: !controller.showDanmakuState.value,
+                    child: IconButton(
+                      onPressed: () => controller.showDanmakuState.value =
+                          !controller.showDanmakuState.value,
+                      icon: const ImageIcon(
+                        AssetImage('assets/icons/icon_danmaku_close.png'),
+                        size: 22,
+                      ),
                     ),
                   ),
-                ),
-                Visibility(
-                  visible: !Platform.isAndroid && !Platform.isIOS,
-                  child: IconButton(
+                  IconButton(
                     onPressed: () {
-                      controller.enterSmallWindow();
+                      controller.showDanmuSettingsSheet();
                     },
-                    icon: const Icon(
-                      Icons.picture_in_picture,
-                      color: Colors.white,
-                      size: 24,
+                    icon: const ImageIcon(
+                      AssetImage('assets/icons/icon_danmaku_setting.png'),
+                      size: 22,
                     ),
                   ),
-                ),
-                IconButton(
-                  onPressed: () {
-                    controller.enterFullScreen();
-                  },
-                  icon: const Icon(
-                    Remix.fullscreen_line,
-                    color: Colors.white,
+                  const Expanded(child: Center()),
+                  Visibility(
+                    visible: !Platform.isAndroid && !Platform.isIOS,
+                    child: IconButton(
+                      key: volumeButtonkey,
+                      onPressed: () {
+                        controller.showVolumeSlider(
+                          volumeButtonkey.currentContext!,
+                        );
+                      },
+                      icon: const Icon(Icons.volume_down, size: 22),
+                    ),
                   ),
-                ),
-              ],
+                  Offstage(
+                    offstage: isPortrait,
+                    child: TextButton(
+                      onPressed: () {
+                        controller.showQualitySheet();
+                      },
+                      child: Obx(
+                        () => Text(
+                          controller.currentQualityInfo.value,
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
+                        ),
+                      ),
+                    ),
+                  ),
+                  Offstage(
+                    offstage: isPortrait,
+                    child: TextButton(
+                      onPressed: () {
+                        controller.showPlayUrlsSheet();
+                      },
+                      child: Text(
+                        controller.currentLineInfo.value,
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                      ),
+                    ),
+                  ),
+                  Visibility(
+                    visible: !Platform.isAndroid && !Platform.isIOS,
+                    child: IconButton(
+                      onPressed: () {
+                        controller.enterSmallWindow();
+                      },
+                      icon: const Icon(Icons.picture_in_picture, size: 22),
+                    ),
+                  ),
+                  IconButton(
+                    onPressed: () {
+                      controller.enterFullScreen();
+                    },
+                    icon: const Icon(Remix.fullscreen_line),
+                  ),
+                ],
+              ),
             ),
           ),
         ),
       ),
-      Obx(
-        () => Offstage(
-          offstage: !controller.showGestureTip.value,
-          child: Center(
-            child: Container(
-              padding: const EdgeInsets.all(12),
-              decoration: BoxDecoration(
-                color: Colors.grey.shade900,
-                borderRadius: BorderRadius.circular(12),
-              ),
-              child: Text(
-                controller.gestureTipText.value,
-                style: const TextStyle(fontSize: 18, color: Colors.white),
-              ),
-            ),
-          ),
-        ),
-      ),
+      _buildGestureTip(controller),
     ],
+  );
+}
+
+Widget _overlayControlsTheme({required Widget child}) {
+  return IconButtonTheme(
+    data: IconButtonThemeData(
+      style: IconButton.styleFrom(
+        foregroundColor: Colors.white,
+        backgroundColor: Colors.white.withAlpha(24),
+        disabledForegroundColor: Colors.white54,
+        minimumSize: const Size(40, 40),
+        tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+        padding: EdgeInsets.zero,
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(AppDesignTokens.radius12),
+          side: BorderSide(color: Colors.white.withAlpha(28)),
+        ),
+      ),
+    ),
+    child: TextButtonTheme(
+      data: TextButtonThemeData(
+        style: TextButton.styleFrom(
+          foregroundColor: Colors.white,
+          backgroundColor: Colors.white.withAlpha(24),
+          minimumSize: const Size(44, 40),
+          tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+          padding: const EdgeInsets.symmetric(horizontal: 10),
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(AppDesignTokens.radius12),
+            side: BorderSide(color: Colors.white.withAlpha(28)),
+          ),
+          textStyle: const TextStyle(
+            color: Colors.white,
+            fontSize: 14,
+            fontWeight: FontWeight.w700,
+          ),
+        ),
+      ),
+      child: child,
+    ),
+  );
+}
+
+Widget _buildGestureTip(LiveRoomController controller) {
+  return Obx(
+    () => Offstage(
+      offstage: !controller.showGestureTip.value,
+      child: Center(
+        child: Container(
+          padding: const EdgeInsets.all(12),
+          decoration: BoxDecoration(
+            color: Colors.black.withAlpha(204),
+            borderRadius: BorderRadius.circular(AppDesignTokens.radius12),
+            border: Border.all(color: Colors.white.withAlpha(36)),
+          ),
+          child: Text(
+            controller.gestureTipText.value,
+            style: const TextStyle(fontSize: 18, color: Colors.white),
+          ),
+        ),
+      ),
+    ),
   );
 }
 
@@ -659,7 +629,7 @@ void showLinesInfo(LiveRoomController controller) {
     child: ListView.builder(
       padding: EdgeInsets.zero,
       itemCount: controller.playUrls.length,
-      itemBuilder: (_, i) {
+      itemBuilder: (context, i) {
         return ListTile(
           selected: controller.currentLineIndex == i,
           title: Text.rich(
@@ -671,7 +641,7 @@ void showLinesInfo(LiveRoomController controller) {
                   decoration: BoxDecoration(
                     borderRadius: AppStyle.radius4,
                     border: Border.all(
-                      color: Colors.grey,
+                      color: Theme.of(context).dividerColor,
                     ),
                   ),
                   padding: AppStyle.edgeInsetsH4,

--- a/simple_live_app/lib/modules/mine/account/account_page.dart
+++ b/simple_live_app/lib/modules/mine/account/account_page.dart
@@ -1,96 +1,193 @@
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import 'package:simple_live_app/app/app_style.dart';
+import 'package:simple_live_app/app/design_system/app_design_tokens.dart';
+import 'package:simple_live_app/app/design_system/app_theme_extension.dart';
 import 'package:simple_live_app/app/utils.dart';
 import 'package:simple_live_app/modules/mine/account/account_controller.dart';
 import 'package:simple_live_app/services/bilibili_account_service.dart';
 import 'package:simple_live_app/services/platform_service.dart';
+import 'package:simple_live_app/widgets/settings/settings_card.dart';
 
 class AccountPage extends GetView<AccountController> {
   const AccountPage({super.key});
 
   @override
   Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final semantic = context.appTheme;
+
     return Scaffold(
-      appBar: AppBar(
-        title: const Text("账号管理"),
+      appBar: AppBar(title: const Text('账号管理')),
+      body: Align(
+        alignment: Alignment.topCenter,
+        child: ConstrainedBox(
+          constraints: const BoxConstraints(maxWidth: 760),
+          child: ListView(
+            padding: const EdgeInsets.fromLTRB(16, 12, 16, 32),
+            children: [
+              Container(
+                padding: const EdgeInsets.all(AppDesignTokens.space16),
+                decoration: BoxDecoration(
+                  color: theme.colorScheme.primary.withAlpha(14),
+                  borderRadius: BorderRadius.circular(AppDesignTokens.radius12),
+                  border: Border.all(
+                    color: theme.colorScheme.primary.withAlpha(36),
+                  ),
+                ),
+                child: Row(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Icon(
+                      Icons.info_outline_rounded,
+                      size: 20,
+                      color: theme.colorScheme.primary,
+                    ),
+                    const SizedBox(width: AppDesignTokens.space12),
+                    Expanded(
+                      child: Text(
+                        '哔哩哔哩账号需要登录才能观看高清晰度直播，其他平台暂无此限制。',
+                        style: theme.textTheme.bodyMedium?.copyWith(
+                          color: semantic.textSecondary,
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+              const _SectionHeading(title: '平台账号', top: 24),
+              SettingsCard(
+                child: Column(
+                  children: [
+                    Obx(
+                      () => _AccountTile(
+                        logo: 'assets/images/bilibili_2.png',
+                        title: '哔哩哔哩',
+                        subtitle: BiliBiliAccountService.instance.name.value,
+                        trailing: BiliBiliAccountService.instance.logined.value
+                            ? const Icon(Icons.logout_rounded)
+                            : null,
+                        onTap: controller.bilibiliTap,
+                      ),
+                    ),
+                    AppStyle.divider,
+                    const _AccountTile(
+                      logo: 'assets/images/douyu.png',
+                      title: '斗鱼直播',
+                      subtitle: '无需登录',
+                      enabled: false,
+                    ),
+                    AppStyle.divider,
+                    Obx(
+                      () => _AccountTile(
+                        logo: 'assets/images/huya.png',
+                        title: '虎牙直播',
+                        subtitle: PlatformService.instance.huyaSdkUa.value.isEmpty
+                            ? '点击拉取最新配置'
+                            : '已自定义 HYSDK_UA',
+                        onTap: () async {
+                          final result = await Utils.showAlertDialog(
+                            '是否从网络拉取虎牙最新配置？',
+                            title: '拉取虎牙配置',
+                          );
+                          if (result) {
+                            await PlatformService.instance.fetchHuyaSdkUa();
+                          }
+                        },
+                      ),
+                    ),
+                    AppStyle.divider,
+                    Obx(
+                      () => _AccountTile(
+                        logo: 'assets/images/douyin.png',
+                        title: '抖音直播',
+                        subtitle: PlatformService.instance.douyinName.value,
+                        trailing: PlatformService.instance.douyinLogined.value
+                            ? const Icon(Icons.logout_rounded)
+                            : null,
+                        onTap: controller.douyinTap,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          ),
+        ),
       ),
-      body: ListView(
-        children: [
-          const Padding(
-            padding: AppStyle.edgeInsetsA12,
-            child: Text(
-              "哔哩哔哩账号需要登录才能看高清晰度的直播，其他平台暂无此限制。",
-              textAlign: TextAlign.center,
-            ),
+    );
+  }
+}
+
+class _AccountTile extends StatelessWidget {
+  const _AccountTile({
+    required this.logo,
+    required this.title,
+    required this.subtitle,
+    this.trailing,
+    this.onTap,
+    this.enabled = true,
+  });
+
+  final String logo;
+  final String title;
+  final String subtitle;
+  final Widget? trailing;
+  final Function()? onTap;
+  final bool enabled;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final semantic = context.appTheme;
+    return ListTile(
+      enabled: enabled,
+      visualDensity: VisualDensity.compact,
+      minVerticalPadding: 10,
+      contentPadding: const EdgeInsets.only(left: 16, right: 12),
+      leading: Image.asset(logo, width: 36, height: 36),
+      title: Text(
+        title,
+        style: theme.textTheme.titleSmall?.copyWith(
+          color: enabled ? semantic.textPrimary : semantic.textDisabled,
+          fontWeight: FontWeight.w600,
+        ),
+      ),
+      subtitle: Text(
+        subtitle,
+        maxLines: 2,
+        overflow: TextOverflow.ellipsis,
+        style: theme.textTheme.bodySmall?.copyWith(
+          color: enabled ? semantic.textSecondary : semantic.textDisabled,
+        ),
+      ),
+      trailing: trailing ??
+          Icon(
+            Icons.chevron_right_rounded,
+            color: enabled ? semantic.textTertiary : semantic.textDisabled,
           ),
-          Obx(
-            () => ListTile(
-              leading: Image.asset(
-                'assets/images/bilibili_2.png',
-                width: 36,
-                height: 36,
-              ),
-              title: const Text("哔哩哔哩"),
-              subtitle: Text(BiliBiliAccountService.instance.name.value),
-              trailing: BiliBiliAccountService.instance.logined.value
-                  ? const Icon(Icons.logout)
-                  : const Icon(Icons.chevron_right),
-              onTap: controller.bilibiliTap,
-            ),
-          ),
-          ListTile(
-            leading: Image.asset(
-              'assets/images/douyu.png',
-              width: 36,
-              height: 36,
-            ),
-            title: const Text("斗鱼直播"),
-            subtitle: const Text("无需登录"),
-            enabled: false,
-            trailing: const Icon(Icons.chevron_right),
-          ),
-          Obx(
-            () => ListTile(
-              leading: Image.asset(
-                'assets/images/huya.png',
-                width: 36,
-                height: 36,
-              ),
-              title: const Text("虎牙直播"),
-              subtitle: Text(
-                PlatformService.instance.huyaSdkUa.value.isEmpty
-                    ? "点击拉取最新配置"
-                    : "已自定义 HYSDK_UA",
-              ),
-              trailing: const Icon(Icons.chevron_right),
-              onTap: () async {
-                var result = await Utils.showAlertDialog(
-                  "是否从网络拉取虎牙最新配置？",
-                  title: "拉取虎牙配置",
-                );
-                if (result) {
-                  await PlatformService.instance.fetchHuyaSdkUa();
-                }
-              },
-            ),
-          ),
-          Obx(
-            () => ListTile(
-              leading: Image.asset(
-                'assets/images/douyin.png',
-                width: 36,
-                height: 36,
-              ),
-              title: const Text("抖音直播"),
-              subtitle: Text(PlatformService.instance.douyinName.value),
-              trailing: PlatformService.instance.douyinLogined.value
-                  ? const Icon(Icons.logout)
-                  : const Icon(Icons.chevron_right),
-              onTap: controller.douyinTap,
-            ),
-          ),
-        ],
+      onTap: onTap,
+    );
+  }
+}
+
+class _SectionHeading extends StatelessWidget {
+  const _SectionHeading({required this.title, this.top = 0});
+
+  final String title;
+  final double top;
+
+  @override
+  Widget build(BuildContext context) {
+    final semantic = context.appTheme;
+    return Padding(
+      padding: EdgeInsets.fromLTRB(4, top, 4, AppDesignTokens.space8),
+      child: Text(
+        title,
+        style: Theme.of(context).textTheme.titleSmall?.copyWith(
+          color: semantic.textSecondary,
+          fontWeight: FontWeight.w700,
+        ),
       ),
     );
   }

--- a/simple_live_app/lib/modules/mine/history/history_page.dart
+++ b/simple_live_app/lib/modules/mine/history/history_page.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
-import 'package:simple_live_app/app/app_style.dart';
+import 'package:simple_live_app/app/design_system/app_design_tokens.dart';
+import 'package:simple_live_app/app/design_system/app_theme_extension.dart';
 import 'package:simple_live_app/app/sites.dart';
 import 'package:simple_live_app/app/utils.dart';
 import 'package:simple_live_app/modules/mine/history/history_controller.dart';
@@ -13,90 +14,180 @@ class HistoryPage extends GetView<HistoryController> {
 
   @override
   Widget build(BuildContext context) {
-    var rowCount = MediaQuery.of(context).size.width ~/ 500;
-    if (rowCount < 1) rowCount = 1;
+    final theme = Theme.of(context);
+    final semantic = context.appTheme;
+
     return Scaffold(
       appBar: AppBar(
-        title: const Text("观看记录"),
+        centerTitle: false,
+        titleSpacing: AppDesignTokens.space24,
+        toolbarHeight: 68,
+        title: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Text(
+              '观看记录',
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+              style: theme.textTheme.headlineSmall?.copyWith(
+                color: semantic.textPrimary,
+                fontWeight: FontWeight.w700,
+              ),
+            ),
+            Text(
+              '最近访问的直播间',
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+              style: theme.textTheme.labelMedium?.copyWith(
+                color: semantic.textTertiary,
+              ),
+            ),
+          ],
+        ),
         actions: [
           TextButton.icon(
             onPressed: controller.clean,
-            icon: const Icon(Icons.delete_outline),
-            label: const Text("清空"),
+            icon: const Icon(Icons.delete_sweep_outlined),
+            label: const Text('清空'),
           ),
+          const SizedBox(width: AppDesignTokens.space8),
         ],
       ),
-      body: PageGridView(
-        crossAxisSpacing: 12,
-        crossAxisCount: rowCount,
-        pageController: controller,
-        firstRefresh: true,
-        itemBuilder: (_, i) {
-          var item = controller.list[i];
-          var site = Sites.allSites[item.siteId]!;
-          return Dismissible(
-            key: ValueKey(item.id),
-            direction: DismissDirection.endToStart,
-            background: Container(
-              color: Colors.red,
-              padding: AppStyle.edgeInsetsA12,
-              alignment: Alignment.centerRight,
-              child: const Icon(
-                Icons.delete,
-                color: Colors.white,
-              ),
-            ),
-            confirmDismiss: (direction) async {
-              return await Utils.showAlertDialog("确定要删除此记录吗?", title: "删除记录");
-            },
-            onDismissed: (_) {
-              controller.removeItem(item);
-            },
-            child: ListTile(
-              leading: NetImage(
-                item.face,
-                width: 48,
-                height: 48,
-                borderRadius: 24,
-              ),
-              title: Text(item.userName),
-              subtitle: Row(
-                children: [
-                  Expanded(
-                    child: Row(
-                      children: [
-                        Image.asset(
-                          site.logo,
-                          width: 20,
+      body: LayoutBuilder(
+        builder: (context, constraints) {
+          final viewportWidth = constraints.maxWidth > 1040
+              ? 1040.0
+              : constraints.maxWidth;
+          final availableWidth = viewportWidth - 32;
+          var rowCount = (availableWidth / 480).floor();
+          if (rowCount < 1) rowCount = 1;
+          if (rowCount > 2) rowCount = 2;
+
+          return Align(
+            alignment: Alignment.topCenter,
+            child: SizedBox(
+              width: viewportWidth,
+              child: PageGridView(
+                padding: const EdgeInsets.fromLTRB(16, 16, 16, 24),
+                mainAxisSpacing: AppDesignTokens.space8,
+                crossAxisSpacing: AppDesignTokens.space8,
+                crossAxisCount: rowCount,
+                pageController: controller,
+                firstRefresh: true,
+                itemBuilder: (_, i) {
+                  final item = controller.list[i];
+                  final site = Sites.allSites[item.siteId]!;
+                  return Dismissible(
+                    key: ValueKey(item.id),
+                    direction: DismissDirection.endToStart,
+                    background: Container(
+                      decoration: BoxDecoration(
+                        color: theme.colorScheme.errorContainer,
+                        borderRadius: BorderRadius.circular(
+                          AppDesignTokens.radius12,
                         ),
-                        AppStyle.hGap4,
-                        Text(
-                          site.name,
-                          style: const TextStyle(
-                            fontSize: 12,
-                            color: Colors.grey,
+                      ),
+                      padding: const EdgeInsets.symmetric(
+                        horizontal: AppDesignTokens.space16,
+                      ),
+                      alignment: Alignment.centerRight,
+                      child: Icon(
+                        Icons.delete_outline_rounded,
+                        color: theme.colorScheme.onErrorContainer,
+                        semanticLabel: '删除记录',
+                      ),
+                    ),
+                    confirmDismiss: (_) => Utils.showAlertDialog(
+                      '确定要删除此记录吗?',
+                      title: '删除记录',
+                    ),
+                    onDismissed: (_) => controller.removeItem(item),
+                    child: Material(
+                      color: semantic.secondarySurface,
+                      clipBehavior: Clip.antiAlias,
+                      shape: RoundedRectangleBorder(
+                        borderRadius: BorderRadius.circular(
+                          AppDesignTokens.radius12,
+                        ),
+                        side: BorderSide(color: semantic.border),
+                      ),
+                      child: ListTile(
+                        minVerticalPadding: AppDesignTokens.space8,
+                        contentPadding: const EdgeInsets.symmetric(
+                          horizontal: AppDesignTokens.space12,
+                          vertical: AppDesignTokens.space4,
+                        ),
+                        leading: NetImage(
+                          item.face,
+                          width: 48,
+                          height: 48,
+                          borderRadius: 24,
+                        ),
+                        title: Text(
+                          item.userName,
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
+                          style: theme.textTheme.titleSmall?.copyWith(
+                            color: semantic.textPrimary,
+                            fontWeight: FontWeight.w700,
                           ),
                         ),
-                      ],
+                        subtitle: Padding(
+                          padding: const EdgeInsets.only(
+                            top: AppDesignTokens.space4,
+                          ),
+                          child: Row(
+                            children: [
+                              Image.asset(site.logo, width: 16, height: 16),
+                              const SizedBox(width: AppDesignTokens.space4),
+                              Expanded(
+                                child: Text(
+                                  site.name,
+                                  maxLines: 1,
+                                  overflow: TextOverflow.ellipsis,
+                                  style: theme.textTheme.bodySmall?.copyWith(
+                                    color: semantic.textSecondary,
+                                  ),
+                                ),
+                              ),
+                              const SizedBox(width: AppDesignTokens.space8),
+                              Flexible(
+                                child: Text(
+                                  Utils.parseTime(item.updateTime),
+                                  maxLines: 1,
+                                  overflow: TextOverflow.ellipsis,
+                                  textAlign: TextAlign.end,
+                                  style: theme.textTheme.bodySmall?.copyWith(
+                                    color: semantic.textTertiary,
+                                  ),
+                                ),
+                              ),
+                            ],
+                          ),
+                        ),
+                        trailing: Icon(
+                          Icons.chevron_right_rounded,
+                          color: semantic.textTertiary,
+                        ),
+                        onTap: () {
+                          AppNavigator.toLiveRoomDetail(
+                            site: site,
+                            roomId: item.roomId,
+                          );
+                        },
+                        onLongPress: () async {
+                          final result = await Utils.showAlertDialog(
+                            '确定要删除此记录吗?',
+                            title: '删除记录',
+                          );
+                          if (result) controller.removeItem(item);
+                        },
+                      ),
                     ),
-                  ),
-                  Text(
-                    Utils.parseTime(item.updateTime),
-                    style: const TextStyle(fontSize: 12, color: Colors.grey),
-                  ),
-                ],
+                  );
+                },
               ),
-              onTap: () {
-                AppNavigator.toLiveRoomDetail(site: site, roomId: item.roomId);
-              },
-              onLongPress: () async {
-                var result =
-                    await Utils.showAlertDialog("确定要删除此记录吗?", title: "删除记录");
-                if (!result) {
-                  return;
-                }
-                controller.removeItem(item);
-              },
             ),
           );
         },

--- a/simple_live_app/lib/modules/mine/mine_page.dart
+++ b/simple_live_app/lib/modules/mine/mine_page.dart
@@ -4,10 +4,13 @@ import 'package:flutter/services.dart';
 import 'package:get/get.dart';
 import 'package:remixicon/remixicon.dart';
 import 'package:simple_live_app/app/app_style.dart';
+import 'package:simple_live_app/app/design_system/app_design_tokens.dart';
+import 'package:simple_live_app/app/design_system/app_theme_extension.dart';
 import 'package:simple_live_app/app/log.dart';
 import 'package:simple_live_app/app/utils.dart';
 import 'package:simple_live_app/routes/route_path.dart';
 import 'package:simple_live_app/services/signalr_service.dart';
+import 'package:simple_live_app/widgets/settings/settings_card.dart';
 import 'package:url_launcher/url_launcher_string.dart';
 
 class MinePage extends StatelessWidget {
@@ -15,6 +18,9 @@ class MinePage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final semantic = context.appTheme;
+
     return AnnotatedRegion<SystemUiOverlayStyle>(
       value: Get.isDarkMode
           ? SystemUiOverlayStyle.light.copyWith(
@@ -24,264 +30,316 @@ class MinePage extends StatelessWidget {
               systemNavigationBarColor: Colors.transparent,
             ),
       child: SafeArea(
-        child: ListView(
-          padding: AppStyle.edgeInsetsA4,
-          children: [
-            AppStyle.vGap12,
-            ListTile(
-              leading: Image.asset(
-                'assets/images/logo.png',
-                width: 56,
-                height: 56,
-              ),
-              title: const Text(
-                "Slive",
-                style: TextStyle(height: 1.0),
-              ),
-              subtitle: const Text("我就默默看你表演"),
-              trailing: const Icon(Icons.chevron_right),
-              onTap: () {
-                Get.dialog(AboutDialog(
-                  applicationIcon: Image.asset(
-                    'assets/images/logo.png',
-                    width: 48,
-                    height: 48,
-                  ),
-                  applicationName: "Slive",
-                  applicationVersion: "我就默默看你表演",
-                  applicationLegalese: "Ver ${Utils.packageInfo.version}",
-                ));
-              },
-            ),
-            Divider(
-              indent: 12,
-              endIndent: 12,
-              color: Colors.grey.withAlpha(25),
-            ),
-            _buildCard(
-              context,
+        child: Align(
+          alignment: Alignment.topCenter,
+          child: ConstrainedBox(
+            constraints: const BoxConstraints(maxWidth: 840),
+            child: ListView(
+              padding: const EdgeInsets.fromLTRB(16, 20, 16, 32),
               children: [
-                ListTile(
-                  leading: const Icon(Remix.history_line),
-                  title: const Text("观看记录"),
-                  trailing: const Icon(
-                    Icons.chevron_right,
-                    color: Colors.grey,
-                  ),
-                  onTap: () {
-                    Get.toNamed(RoutePath.kHistory);
-                  },
-                ),
-              ],
-            ),
-            Divider(
-              indent: 12,
-              endIndent: 12,
-              color: Colors.grey.withAlpha(25),
-            ),
-            ListTile(
-              leading: const Icon(Remix.account_circle_line),
-              title: const Text("账号管理"),
-              trailing: const Icon(
-                Icons.chevron_right,
-                color: Colors.grey,
-              ),
-              onTap: () {
-                Get.toNamed(RoutePath.kSettingsAccount);
-              },
-            ),
-            Divider(
-              indent: 12,
-              endIndent: 12,
-              color: Colors.grey.withAlpha(25),
-            ),
-            ListTile(
-              leading: const Icon(Icons.devices),
-              title: const Text("数据同步"),
-              trailing: const Icon(
-                Icons.chevron_right,
-                color: Colors.grey,
-              ),
-              onTap: () {
-                Get.toNamed(RoutePath.kSync);
-              },
-            ),
-            Divider(
-              indent: 12,
-              endIndent: 12,
-              color: Colors.grey.withAlpha(25),
-            ),
-            ListTile(
-              leading: const Icon(Remix.link),
-              title: const Text("链接解析"),
-              trailing: const Icon(
-                Icons.chevron_right,
-                color: Colors.grey,
-              ),
-              onTap: () {
-                Get.toNamed(RoutePath.kTools);
-              },
-            ),
-            Divider(
-              indent: 12,
-              endIndent: 12,
-              color: Colors.grey.withAlpha(25),
-            ),
-            _buildCard(
-              context,
-              children: [
-                ListTile(
-                  leading: const Icon(Remix.moon_line),
-                  title: const Text("外观设置"),
-                  trailing: const Icon(
-                    Icons.chevron_right,
-                    color: Colors.grey,
-                  ),
-                  onTap: () {
-                    Get.toNamed(RoutePath.kAppstyleSetting);
-                  },
-                ),
-                ListTile(
-                  leading: const Icon(Remix.home_2_line),
-                  title: const Text("主页设置"),
-                  trailing: const Icon(
-                    Icons.chevron_right,
-                    color: Colors.grey,
-                  ),
-                  onTap: () {
-                    Get.toNamed(RoutePath.kSettingsIndexed);
-                  },
-                ),
-                ListTile(
-                  leading: const Icon(Remix.play_circle_line),
-                  title: const Text("直播设置"),
-                  trailing: const Icon(
-                    Icons.chevron_right,
-                    color: Colors.grey,
-                  ),
-                  onTap: () {
-                    Get.toNamed(RoutePath.kSettingsPlay);
-                  },
-                ),
-                ListTile(
-                  leading: const Icon(Remix.text),
-                  title: const Text("弹幕设置"),
-                  trailing: const Icon(
-                    Icons.chevron_right,
-                    color: Colors.grey,
-                  ),
-                  onTap: () {
-                    Get.toNamed(RoutePath.kSettingsDanmu);
-                  },
-                ),
-                ListTile(
-                  leading: const Icon(Remix.timer_2_line),
-                  title: const Text("定时关闭"),
-                  trailing: const Icon(
-                    Icons.chevron_right,
-                    color: Colors.grey,
-                  ),
-                  onTap: () {
-                    Get.toNamed(RoutePath.kSettingsAutoExit);
-                  },
-                ),
-                ListTile(
-                  leading: const Icon(Remix.apps_line),
-                  title: const Text("其他设置"),
-                  trailing: const Icon(
-                    Icons.chevron_right,
-                    color: Colors.grey,
-                  ),
-                  onTap: () {
-                    Get.toNamed(RoutePath.kSettingsOther);
-                  },
-                ),
-                if (kDebugMode)
-                  ListTile(
-                    leading: const Icon(Remix.apps_line),
-                    title: const Text("测试"),
-                    trailing: const Icon(
-                      Icons.chevron_right,
-                      color: Colors.grey,
+                Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 4),
+                  child: Text(
+                    '我的',
+                    style: theme.textTheme.headlineMedium?.copyWith(
+                      color: semantic.textPrimary,
+                      fontWeight: FontWeight.w800,
                     ),
-                    onTap: () async {
-                      SignalRService signalRService = SignalRService();
-                      await signalRService.connect();
-                      //Get.toNamed(RoutePath.kTest);
-                      var room = await signalRService.createRoom();
-                      Log.logPrint(room);
-                    },
                   ),
-              ],
-            ),
-            Divider(
-              indent: 12,
-              endIndent: 12,
-              color: Colors.grey.withAlpha(25),
-            ),
-            _buildCard(
-              context,
-              children: [
-                const ListTile(
-                  leading: Icon(Remix.error_warning_line),
-                  title: Text("免责声明"),
-                  trailing: Icon(
-                    Icons.chevron_right,
-                    color: Colors.grey,
-                  ),
-                  onTap: Utils.showStatement,
                 ),
-                ListTile(
-                  leading: const Icon(Remix.github_line),
-                  title: const Text("开源主页"),
-                  trailing: const Icon(
-                    Icons.chevron_right,
-                    color: Colors.grey,
+                const SizedBox(height: AppDesignTokens.space16),
+                SettingsCard(
+                  child: InkWell(
+                    onTap: () => _showAboutDialog(context),
+                    child: Padding(
+                      padding: const EdgeInsets.all(AppDesignTokens.space16),
+                      child: Row(
+                        children: [
+                          Container(
+                            width: 72,
+                            height: 72,
+                            padding: const EdgeInsets.all(8),
+                            decoration: BoxDecoration(
+                              color: semantic.elevatedSurface,
+                              borderRadius: BorderRadius.circular(
+                                AppDesignTokens.radius16,
+                              ),
+                              border: Border.all(color: semantic.border),
+                            ),
+                            child: Image.asset('assets/images/logo.png'),
+                          ),
+                          const SizedBox(width: AppDesignTokens.space16),
+                          Expanded(
+                            child: Column(
+                              crossAxisAlignment: CrossAxisAlignment.start,
+                              children: [
+                                Text(
+                                  'Slive',
+                                  style: theme.textTheme.headlineSmall?.copyWith(
+                                    color: semantic.textPrimary,
+                                    fontWeight: FontWeight.w800,
+                                  ),
+                                ),
+                                const SizedBox(height: AppDesignTokens.space4),
+                                Text(
+                                  '我就默默看你表演',
+                                  style: theme.textTheme.bodyMedium?.copyWith(
+                                    color: semantic.textSecondary,
+                                  ),
+                                ),
+                                const SizedBox(height: AppDesignTokens.space8),
+                                Container(
+                                  padding: const EdgeInsets.symmetric(
+                                    horizontal: 8,
+                                    vertical: 4,
+                                  ),
+                                  decoration: BoxDecoration(
+                                    color: theme.colorScheme.primary.withAlpha(18),
+                                    borderRadius: BorderRadius.circular(999),
+                                  ),
+                                  child: Text(
+                                    'Ver ${Utils.packageInfo.version}',
+                                    style: theme.textTheme.labelSmall?.copyWith(
+                                      color: theme.colorScheme.primary,
+                                      fontWeight: FontWeight.w600,
+                                    ),
+                                  ),
+                                ),
+                              ],
+                            ),
+                          ),
+                          Icon(
+                            Icons.chevron_right_rounded,
+                            color: semantic.textTertiary,
+                          ),
+                        ],
+                      ),
+                    ),
                   ),
-                  onTap: () {
-                    launchUrlString(
-                      "https://github.com/slotsun/dart_simple_live",
-                      mode: LaunchMode.externalApplication,
-                    );
-                  },
                 ),
-                ListTile(
-                  leading: const Icon(Remix.upload_2_line),
-                  title: const Text("检查更新"),
-                  trailing: Row(
-                    mainAxisSize: MainAxisSize.min,
+                const _SectionHeading(title: '内容', top: 24),
+                SettingsCard(
+                  child: _MineTile(
+                    icon: Remix.history_line,
+                    title: '观看记录',
+                    subtitle: '查看最近访问的直播间',
+                    onTap: () => Get.toNamed(RoutePath.kHistory),
+                  ),
+                ),
+                const _SectionHeading(title: '账号与数据', top: 24),
+                SettingsCard(
+                  child: Column(
                     children: [
-                      Text("Ver ${Utils.packageInfo.version}"),
-                      AppStyle.hGap4,
-                      const Icon(
-                        Icons.chevron_right,
-                        color: Colors.grey,
+                      _MineTile(
+                        icon: Remix.account_circle_line,
+                        title: '账号管理',
+                        onTap: () => Get.toNamed(RoutePath.kSettingsAccount),
+                      ),
+                      AppStyle.divider,
+                      _MineTile(
+                        icon: Icons.devices_rounded,
+                        title: '数据同步',
+                        onTap: () => Get.toNamed(RoutePath.kSync),
+                      ),
+                      AppStyle.divider,
+                      _MineTile(
+                        icon: Remix.link,
+                        title: '链接解析',
+                        onTap: () => Get.toNamed(RoutePath.kTools),
                       ),
                     ],
                   ),
-                  onTap: () {
-                    Utils.checkUpdate(showMsg: true);
-                  },
+                ),
+                const _SectionHeading(title: '设置', top: 24),
+                SettingsCard(
+                  child: Column(
+                    children: [
+                      _MineTile(
+                        icon: Remix.moon_line,
+                        title: '外观设置',
+                        onTap: () => Get.toNamed(RoutePath.kAppstyleSetting),
+                      ),
+                      AppStyle.divider,
+                      _MineTile(
+                        icon: Remix.home_2_line,
+                        title: '主页设置',
+                        onTap: () => Get.toNamed(RoutePath.kSettingsIndexed),
+                      ),
+                      AppStyle.divider,
+                      _MineTile(
+                        icon: Remix.play_circle_line,
+                        title: '直播设置',
+                        onTap: () => Get.toNamed(RoutePath.kSettingsPlay),
+                      ),
+                      AppStyle.divider,
+                      _MineTile(
+                        icon: Remix.text,
+                        title: '弹幕设置',
+                        onTap: () => Get.toNamed(RoutePath.kSettingsDanmu),
+                      ),
+                      AppStyle.divider,
+                      _MineTile(
+                        icon: Remix.timer_2_line,
+                        title: '定时关闭',
+                        onTap: () => Get.toNamed(RoutePath.kSettingsAutoExit),
+                      ),
+                      AppStyle.divider,
+                      _MineTile(
+                        icon: Remix.apps_line,
+                        title: '其他设置',
+                        onTap: () => Get.toNamed(RoutePath.kSettingsOther),
+                      ),
+                      if (kDebugMode) AppStyle.divider,
+                      if (kDebugMode)
+                        _MineTile(
+                          icon: Remix.bug_line,
+                          title: '测试',
+                          onTap: () async {
+                            final signalRService = SignalRService();
+                            await signalRService.connect();
+                            final room = await signalRService.createRoom();
+                            Log.logPrint(room);
+                          },
+                        ),
+                    ],
+                  ),
+                ),
+                const _SectionHeading(title: '关于', top: 24),
+                SettingsCard(
+                  child: Column(
+                    children: [
+                      const _MineTile(
+                        icon: Remix.error_warning_line,
+                        title: '免责声明',
+                        onTap: Utils.showStatement,
+                      ),
+                      AppStyle.divider,
+                      _MineTile(
+                        icon: Remix.github_line,
+                        title: '开源主页',
+                        onTap: () {
+                          launchUrlString(
+                            'https://github.com/slotsun/dart_simple_live',
+                            mode: LaunchMode.externalApplication,
+                          );
+                        },
+                      ),
+                      AppStyle.divider,
+                      _MineTile(
+                        icon: Remix.upload_2_line,
+                        title: '检查更新',
+                        value: 'Ver ${Utils.packageInfo.version}',
+                        onTap: () => Utils.checkUpdate(showMsg: true),
+                      ),
+                    ],
+                  ),
                 ),
               ],
             ),
-          ],
+          ),
         ),
       ),
     );
   }
 
-  Widget _buildCard(BuildContext context, {required List<Widget> children}) {
-    return Theme(
-      data: Theme.of(context).copyWith(
-        listTileTheme: ListTileThemeData(
-          shape: RoundedRectangleBorder(borderRadius: AppStyle.radius8),
+  void _showAboutDialog(BuildContext context) {
+    Get.dialog(
+      AboutDialog(
+        applicationIcon: Image.asset(
+          'assets/images/logo.png',
+          width: 48,
+          height: 48,
+        ),
+        applicationName: 'Slive',
+        applicationVersion: '我就默默看你表演',
+        applicationLegalese: 'Ver ${Utils.packageInfo.version}',
+      ),
+    );
+  }
+}
+
+class _MineTile extends StatelessWidget {
+  const _MineTile({
+    required this.icon,
+    required this.title,
+    required this.onTap,
+    this.subtitle,
+    this.value,
+  });
+
+  final IconData icon;
+  final String title;
+  final String? subtitle;
+  final String? value;
+  final Function()? onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final semantic = context.appTheme;
+    return ListTile(
+      visualDensity: VisualDensity.compact,
+      minVerticalPadding: 10,
+      contentPadding: const EdgeInsets.only(left: 16, right: 12),
+      leading: Icon(icon, color: semantic.textSecondary),
+      title: Text(
+        title,
+        style: theme.textTheme.titleSmall?.copyWith(
+          color: semantic.textPrimary,
+          fontWeight: FontWeight.w600,
         ),
       ),
-      child: Column(
+      subtitle: subtitle == null
+          ? null
+          : Text(
+              subtitle!,
+              maxLines: 2,
+              overflow: TextOverflow.ellipsis,
+              style: theme.textTheme.bodySmall?.copyWith(
+                color: semantic.textSecondary,
+              ),
+            ),
+      trailing: Row(
         mainAxisSize: MainAxisSize.min,
-        crossAxisAlignment: CrossAxisAlignment.stretch,
-        children: children,
+        children: [
+          if (value != null)
+            ConstrainedBox(
+              constraints: const BoxConstraints(maxWidth: 160),
+              child: Text(
+                value!,
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+                style: theme.textTheme.bodySmall?.copyWith(
+                  color: semantic.textSecondary,
+                ),
+              ),
+            ),
+          if (value != null) const SizedBox(width: 4),
+          Icon(Icons.chevron_right_rounded, color: semantic.textTertiary),
+        ],
+      ),
+      onTap: onTap,
+    );
+  }
+}
+
+class _SectionHeading extends StatelessWidget {
+  const _SectionHeading({required this.title, this.top = 0});
+
+  final String title;
+  final double top;
+
+  @override
+  Widget build(BuildContext context) {
+    final semantic = context.appTheme;
+    return Padding(
+      padding: EdgeInsets.fromLTRB(4, top, 4, AppDesignTokens.space8),
+      child: Text(
+        title,
+        style: Theme.of(context).textTheme.titleSmall?.copyWith(
+          color: semantic.textSecondary,
+          fontWeight: FontWeight.w700,
+        ),
       ),
     );
   }

--- a/simple_live_app/lib/modules/mine/parse/parse_page.dart
+++ b/simple_live_app/lib/modules/mine/parse/parse_page.dart
@@ -1,139 +1,177 @@
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import 'package:remixicon/remixicon.dart';
-import 'package:simple_live_app/app/app_style.dart';
+import 'package:simple_live_app/app/design_system/app_design_tokens.dart';
+import 'package:simple_live_app/app/design_system/app_theme_extension.dart';
 import 'package:simple_live_app/modules/mine/parse/parse_controller.dart';
+import 'package:simple_live_app/widgets/settings/settings_card.dart';
 
 class ParsePage extends GetView<ParseController> {
   const ParsePage({super.key});
 
   @override
   Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final semantic = context.appTheme;
+
     return Scaffold(
-      appBar: AppBar(
-        title: const Text("链接解析"),
-      ),
-      body: ListView(
-        padding: AppStyle.edgeInsetsA12,
-        children: [
-          buildCard(
-            context: context,
-            child: ExpansionTile(
-              title: const Text("直播间跳转"),
-              childrenPadding: AppStyle.edgeInsetsH12,
-              initiallyExpanded: true,
-              children: [
-                TextField(
-                  minLines: 3,
-                  maxLines: 3,
-                  controller: controller.roomJumpToController,
-                  textInputAction: TextInputAction.go,
-                  decoration: InputDecoration(
-                    border: const OutlineInputBorder(),
-                    hintText: "输入或粘贴哔哩哔哩直播/虎牙直播/斗鱼直播/抖音直播的链接",
-                    contentPadding: AppStyle.edgeInsetsA12,
-                    enabledBorder: OutlineInputBorder(
-                      borderSide: BorderSide(
-                        color: Colors.grey.withAlpha(50),
-                      ),
-                    ),
-                  ),
-                  onSubmitted: controller.jumpToRoom,
+      appBar: AppBar(title: const Text('链接解析')),
+      body: Align(
+        alignment: Alignment.topCenter,
+        child: ConstrainedBox(
+          constraints: const BoxConstraints(maxWidth: 800),
+          child: ListView(
+            padding: const EdgeInsets.fromLTRB(16, 12, 16, 32),
+            children: [
+              _ParseCard(
+                title: '直播间跳转',
+                subtitle: '解析平台分享链接并打开对应直播间',
+                controller: controller.roomJumpToController,
+                buttonIcon: Remix.play_circle_line,
+                buttonLabel: '链接跳转',
+                onSubmitted: controller.jumpToRoom,
+                onPressed: () => controller.jumpToRoom(
+                  controller.roomJumpToController.text,
                 ),
-                Container(
-                  margin: AppStyle.edgeInsetsB4,
-                  width: double.infinity,
-                  child: TextButton.icon(
-                    onPressed: () {
-                      controller
-                          .jumpToRoom(controller.roomJumpToController.text);
-                    },
-                    icon: const Icon(Remix.play_circle_line),
-                    label: const Text("链接跳转"),
-                  ),
+              ),
+              const SizedBox(height: AppDesignTokens.space16),
+              _ParseCard(
+                title: '获取直链',
+                subtitle: '选择清晰度与线路后复制播放地址',
+                controller: controller.getUrlController,
+                buttonIcon: Remix.link,
+                buttonLabel: '获取直链',
+                onSubmitted: controller.getPlayUrl,
+                onPressed: () => controller.getPlayUrl(
+                  controller.getUrlController.text,
                 ),
-              ],
-            ),
-          ),
-          buildCard(
-            context: context,
-            child: ExpansionTile(
-              title: const Text("获取直链"),
-              childrenPadding: AppStyle.edgeInsetsH12,
-              initiallyExpanded: true,
-              children: [
-                TextField(
-                  minLines: 3,
-                  maxLines: 3,
-                  controller: controller.getUrlController,
-                  textInputAction: TextInputAction.go,
-                  decoration: InputDecoration(
-                    border: const OutlineInputBorder(),
-                    hintText: "输入或粘贴哔哩哔哩直播/虎牙直播/斗鱼直播/抖音直播的链接",
-                    contentPadding: AppStyle.edgeInsetsA12,
-                    enabledBorder: OutlineInputBorder(
-                      borderSide: BorderSide(
-                        color: Colors.grey.withAlpha(50),
-                      ),
-                    ),
-                  ),
-                  onSubmitted: controller.getPlayUrl,
-                ),
-                Container(
-                  margin: AppStyle.edgeInsetsB4,
-                  width: double.infinity,
-                  child: TextButton.icon(
-                    onPressed: () {
-                      controller.getPlayUrl(controller.getUrlController.text);
-                    },
-                    icon: const Icon(Remix.link),
-                    label: const Text("获取直链"),
-                  ),
-                ),
-              ],
-            ),
-          ),
-          const Padding(
-            padding: AppStyle.edgeInsetsV12,
-            child: SelectableText('''支持以下类型的链接解析：
-哔哩哔哩：
+              ),
+              const _SectionHeading(title: '支持的链接', top: 24),
+              SettingsCard(
+                child: Padding(
+                  padding: const EdgeInsets.all(AppDesignTokens.space16),
+                  child: SelectableText(
+                    '''哔哩哔哩
 https://live.bilibili.com/xxxxx
 https://b23.tv/xxxxx
-虎牙直播：
+
+虎牙直播
 https://www.huya.com/xxxxx
-斗鱼直播：
+
+斗鱼直播
 https://www.douyu.com/xxxxx
 https://www.douyu.com/topic/xxxx
-抖音直播：
+
+抖音直播
 https://live.douyin.com/xxxxx
-https://webcast.amemv.com/douyin/webcast/reflow/xxxxx
-''', style: TextStyle(color: Colors.grey)),
+https://webcast.amemv.com/douyin/webcast/reflow/xxxxx''',
+                    style: theme.textTheme.bodySmall?.copyWith(
+                      color: semantic.textSecondary,
+                      height: 1.6,
+                    ),
+                  ),
+                ),
+              ),
+            ],
           ),
-        ],
+        ),
       ),
     );
   }
+}
 
-  Widget buildCard({required BuildContext context, required Widget child}) {
-    return Container(
-      decoration: BoxDecoration(
-        color: Theme.of(context).cardColor,
-        borderRadius: AppStyle.radius8,
-        boxShadow: Get.isDarkMode
-            ? []
-            : [
-                BoxShadow(
-                  blurRadius: 8,
-                  color: Colors.grey.withAlpha(50),
-                )
-              ],
-      ),
-      margin: AppStyle.edgeInsetsB12,
+class _ParseCard extends StatelessWidget {
+  const _ParseCard({
+    required this.title,
+    required this.subtitle,
+    required this.controller,
+    required this.buttonIcon,
+    required this.buttonLabel,
+    required this.onSubmitted,
+    required this.onPressed,
+  });
+
+  final String title;
+  final String subtitle;
+  final TextEditingController controller;
+  final IconData buttonIcon;
+  final String buttonLabel;
+  final ValueChanged<String> onSubmitted;
+  final VoidCallback onPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    final semantic = context.appTheme;
+    final theme = Theme.of(context);
+    return SettingsCard(
       child: Theme(
-        data: Theme.of(context).copyWith(
-          dividerColor: Colors.transparent,
+        data: theme.copyWith(dividerColor: Colors.transparent),
+        child: ExpansionTile(
+          initiallyExpanded: true,
+          tilePadding: const EdgeInsets.symmetric(
+            horizontal: AppDesignTokens.space16,
+            vertical: AppDesignTokens.space4,
+          ),
+          childrenPadding: const EdgeInsets.fromLTRB(16, 0, 16, 16),
+          title: Text(
+            title,
+            style: theme.textTheme.titleMedium?.copyWith(
+              color: semantic.textPrimary,
+              fontWeight: FontWeight.w700,
+            ),
+          ),
+          subtitle: Text(
+            subtitle,
+            style: theme.textTheme.bodySmall?.copyWith(
+              color: semantic.textSecondary,
+            ),
+          ),
+          children: [
+            TextField(
+              minLines: 3,
+              maxLines: 3,
+              controller: controller,
+              textInputAction: TextInputAction.go,
+              decoration: const InputDecoration(
+                border: OutlineInputBorder(),
+                hintText: '输入或粘贴哔哩哔哩、虎牙、斗鱼或抖音直播链接',
+                alignLabelWithHint: true,
+              ),
+              onSubmitted: onSubmitted,
+            ),
+            const SizedBox(height: AppDesignTokens.space12),
+            SizedBox(
+              width: double.infinity,
+              child: FilledButton.icon(
+                onPressed: onPressed,
+                icon: Icon(buttonIcon),
+                label: Text(buttonLabel),
+              ),
+            ),
+          ],
         ),
-        child: child,
+      ),
+    );
+  }
+}
+
+class _SectionHeading extends StatelessWidget {
+  const _SectionHeading({required this.title, this.top = 0});
+
+  final String title;
+  final double top;
+
+  @override
+  Widget build(BuildContext context) {
+    final semantic = context.appTheme;
+    return Padding(
+      padding: EdgeInsets.fromLTRB(4, top, 4, AppDesignTokens.space8),
+      child: Text(
+        title,
+        style: Theme.of(context).textTheme.titleSmall?.copyWith(
+          color: semantic.textSecondary,
+          fontWeight: FontWeight.w700,
+        ),
       ),
     );
   }

--- a/simple_live_app/lib/modules/search/douyin/douyin_search_view.dart
+++ b/simple_live_app/lib/modules/search/douyin/douyin_search_view.dart
@@ -2,9 +2,9 @@ import 'dart:io';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_inappwebview/flutter_inappwebview.dart';
-
 import 'package:get/get.dart';
-import 'package:simple_live_app/app/app_style.dart';
+import 'package:simple_live_app/app/design_system/app_design_tokens.dart';
+import 'package:simple_live_app/app/design_system/app_theme_extension.dart';
 import 'package:simple_live_app/modules/search/douyin/douyin_search_controller.dart';
 import 'package:simple_live_app/routes/app_navigation.dart';
 import 'package:simple_live_app/widgets/keep_alive_wrapper.dart';
@@ -12,38 +12,84 @@ import 'package:simple_live_app/widgets/status/app_loadding_widget.dart';
 
 class DouyinSearchView extends StatelessWidget {
   const DouyinSearchView({super.key});
+
   DouyinSearchController get controller => Get.find<DouyinSearchController>();
 
   @override
   Widget build(BuildContext context) {
-    var roomRowCount = MediaQuery.of(context).size.width ~/ 200;
-    if (roomRowCount < 2) roomRowCount = 2;
+    final theme = Theme.of(context);
+    final semantic = context.appTheme;
 
-    var userRowCount = MediaQuery.of(context).size.width ~/ 500;
-    if (userRowCount < 1) userRowCount = 1;
     return KeepAliveWrapper(
       child: Stack(
         children: [
-          SizedBox(
-            width: double.infinity,
-            height: double.infinity,
+          Positioned.fill(
             child: Center(
-              child: Padding(
-                padding: AppStyle.edgeInsetsA12,
-                child: Column(
-                  mainAxisSize: MainAxisSize.min,
-                  crossAxisAlignment: CrossAxisAlignment.center,
-                  children: [
-                    const Text(
-                      "暂不支持抖音搜索，请打开浏览器搜索，然后复制直播间链接进行解析",
-                      textAlign: TextAlign.center,
+              child: SingleChildScrollView(
+                padding: const EdgeInsets.all(AppDesignTokens.space16),
+                child: ConstrainedBox(
+                  constraints: const BoxConstraints(maxWidth: 420),
+                  child: DecoratedBox(
+                    decoration: BoxDecoration(
+                      color: semantic.elevatedSurface,
+                      borderRadius: BorderRadius.circular(
+                        AppDesignTokens.radius16,
+                      ),
+                      border: Border.all(color: semantic.border),
+                      boxShadow: [
+                        BoxShadow(
+                          color: semantic.shadow,
+                          blurRadius: 12,
+                          offset: const Offset(0, 4),
+                        ),
+                      ],
                     ),
-                    TextButton.icon(
-                      onPressed: controller.openBrowser,
-                      icon: const Icon(Icons.open_in_browser),
-                      label: const Text("打开浏览器"),
+                    child: Padding(
+                      padding: const EdgeInsets.all(AppDesignTokens.space24),
+                      child: Column(
+                        mainAxisSize: MainAxisSize.min,
+                        children: [
+                          Container(
+                            width: 56,
+                            height: 56,
+                            decoration: BoxDecoration(
+                              color: theme.colorScheme.primary.withAlpha(18),
+                              shape: BoxShape.circle,
+                            ),
+                            alignment: Alignment.center,
+                            child: Icon(
+                              Icons.travel_explore_rounded,
+                              color: theme.colorScheme.primary,
+                              size: 28,
+                            ),
+                          ),
+                          const SizedBox(height: AppDesignTokens.space16),
+                          Text(
+                            '暂不支持抖音站内搜索',
+                            textAlign: TextAlign.center,
+                            style: theme.textTheme.titleMedium?.copyWith(
+                              color: semantic.textPrimary,
+                              fontWeight: FontWeight.w700,
+                            ),
+                          ),
+                          const SizedBox(height: AppDesignTokens.space8),
+                          Text(
+                            '请在浏览器中搜索，然后复制直播间链接进行解析。',
+                            textAlign: TextAlign.center,
+                            style: theme.textTheme.bodyMedium?.copyWith(
+                              color: semantic.textSecondary,
+                            ),
+                          ),
+                          const SizedBox(height: AppDesignTokens.space16),
+                          FilledButton.tonalIcon(
+                            onPressed: controller.openBrowser,
+                            icon: const Icon(Icons.open_in_browser_rounded),
+                            label: const Text('打开浏览器'),
+                          ),
+                        ],
+                      ),
                     ),
-                  ],
+                  ),
                 ),
               ),
             ),
@@ -56,22 +102,24 @@ class DouyinSearchView extends StatelessWidget {
               initialSettings: InAppWebViewSettings(
                 useOnLoadResource: true,
                 userAgent:
-                    "Mozilla/5.0 (iPhone; CPU iPhone OS 13_2_3 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.0.3 Mobile/15E148 Safari/604.1 Edg/118.0.0.0",
+                    'Mozilla/5.0 (iPhone; CPU iPhone OS 13_2_3 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.0.3 Mobile/15E148 Safari/604.1 Edg/118.0.0.0',
                 useShouldOverrideUrlLoading: true,
               ),
               onCreateWindow: controller.onCreateWindow,
               shouldOverrideUrlLoading:
                   (webController, navigationAction) async {
-                var uri = navigationAction.request.url;
+                final uri = navigationAction.request.url;
                 if (uri == null) {
                   return NavigationActionPolicy.ALLOW;
                 }
-                if (uri.host == "live.douyin.com") {
-                  var regExp = RegExp(r"live\.douyin\.com/([\d|\w]+)");
-                  var id = regExp.firstMatch(uri.toString())?.group(1) ?? "";
+                if (uri.host == 'live.douyin.com') {
+                  final regExp = RegExp(r'live\.douyin\.com/([\d|\w]+)');
+                  final id = regExp.firstMatch(uri.toString())?.group(1) ?? '';
 
                   AppNavigator.toLiveRoomDetail(
-                      site: controller.site, roomId: id);
+                    site: controller.site,
+                    roomId: id,
+                  );
                   return NavigationActionPolicy.CANCEL;
                 }
                 return NavigationActionPolicy.ALLOW;

--- a/simple_live_app/lib/modules/search/search_list_view.dart
+++ b/simple_live_app/lib/modules/search/search_list_view.dart
@@ -1,88 +1,202 @@
 import 'package:flutter/material.dart';
-
 import 'package:get/get.dart';
-import 'package:simple_live_app/app/app_style.dart';
+import 'package:simple_live_app/app/design_system/app_design_tokens.dart';
+import 'package:simple_live_app/app/design_system/app_theme_extension.dart';
 import 'package:simple_live_app/modules/search/search_list_controller.dart';
 import 'package:simple_live_app/routes/app_navigation.dart';
 import 'package:simple_live_app/widgets/keep_alive_wrapper.dart';
 import 'package:simple_live_app/widgets/live_room_card.dart';
 import 'package:simple_live_app/widgets/net_image.dart';
 import 'package:simple_live_app/widgets/page_grid_view.dart';
+import 'package:simple_live_app/widgets/shadow_card.dart';
 import 'package:simple_live_core/simple_live_core.dart';
 
 class SearchListView extends StatelessWidget {
   final String tag;
   const SearchListView(this.tag, {super.key});
+
   SearchListController get controller =>
       Get.find<SearchListController>(tag: tag);
+
   @override
   Widget build(BuildContext context) {
-    var roomRowCount = MediaQuery.of(context).size.width ~/ 200;
-    if (roomRowCount < 2) roomRowCount = 2;
-
-    var userRowCount = MediaQuery.of(context).size.width ~/ 500;
-    if (userRowCount < 1) userRowCount = 1;
     return KeepAliveWrapper(
-      child: Obx(
-        () => controller.searchMode.value == 0
-            ? PageGridView(
-                pageController: controller,
-                padding: AppStyle.edgeInsetsA12,
-                firstRefresh: false,
-                mainAxisSpacing: 12,
-                crossAxisSpacing: 12,
-                crossAxisCount: roomRowCount,
-                showPageLoadding: true,
-                itemBuilder: (_, i) {
-                  var item = controller.list[i] as LiveRoomItem;
-                  return LiveRoomCard(controller.site, item);
-                },
-              )
-            : PageGridView(
-                crossAxisSpacing: 12,
-                crossAxisCount: userRowCount,
-                pageController: controller,
-                firstRefresh: true,
-                itemBuilder: (_, i) {
-                  var item = controller.list[i] as LiveAnchorItem;
+      child: LayoutBuilder(
+        builder: (context, constraints) {
+          const roomTargetWidth = 280.0;
+          const roomSpacing = AppDesignTokens.space16;
+          const maxRoomColumns = 5;
+          const anchorTargetWidth = 360.0;
+          const anchorSpacing = AppDesignTokens.space12;
+          const maxAnchorColumns = 3;
+          final gutter = _contentGutter(constraints.maxWidth);
 
-                  return ListTile(
-                    leading: NetImage(
-                      item.avatar,
-                      width: 48,
-                      height: 48,
-                      borderRadius: 24,
+          final maxRoomViewportWidth = (roomTargetWidth * maxRoomColumns) +
+              (roomSpacing * (maxRoomColumns - 1)) +
+              (gutter * 2);
+          final roomViewportWidth = constraints.maxWidth > maxRoomViewportWidth
+              ? maxRoomViewportWidth
+              : constraints.maxWidth;
+          final roomAvailableWidth = roomViewportWidth - (gutter * 2);
+          var roomColumnCount = ((roomAvailableWidth + roomSpacing) /
+                  (roomTargetWidth + roomSpacing))
+              .floor();
+          if (roomColumnCount < 1) roomColumnCount = 1;
+          if (roomColumnCount > maxRoomColumns) {
+            roomColumnCount = maxRoomColumns;
+          }
+
+          final maxAnchorViewportWidth =
+              (anchorTargetWidth * maxAnchorColumns) +
+                  (anchorSpacing * (maxAnchorColumns - 1)) +
+                  (gutter * 2);
+          final anchorViewportWidth =
+              constraints.maxWidth > maxAnchorViewportWidth
+                  ? maxAnchorViewportWidth
+                  : constraints.maxWidth;
+          final anchorAvailableWidth = anchorViewportWidth - (gutter * 2);
+          var anchorColumnCount = ((anchorAvailableWidth + anchorSpacing) /
+                  (anchorTargetWidth + anchorSpacing))
+              .floor();
+          if (anchorColumnCount < 1) anchorColumnCount = 1;
+          if (anchorColumnCount > maxAnchorColumns) {
+            anchorColumnCount = maxAnchorColumns;
+          }
+
+          return Obx(
+            () => controller.searchMode.value == 0
+                ? Align(
+                    alignment: Alignment.topCenter,
+                    child: SizedBox(
+                      width: roomViewportWidth,
+                      child: PageGridView(
+                        pageController: controller,
+                        padding: EdgeInsets.fromLTRB(gutter, 20, gutter, 24),
+                        firstRefresh: false,
+                        mainAxisSpacing: roomSpacing,
+                        crossAxisSpacing: roomSpacing,
+                        crossAxisCount: roomColumnCount,
+                        showPageLoadding: true,
+                        itemBuilder: (_, i) {
+                          final item = controller.list[i] as LiveRoomItem;
+                          return LiveRoomCard(controller.site, item);
+                        },
+                      ),
                     ),
-                    title: Text(item.userName),
-                    subtitle: Row(
-                      mainAxisSize: MainAxisSize.min,
-                      children: [
-                        Container(
-                          width: 8,
-                          height: 8,
-                          decoration: BoxDecoration(
-                            color: item.liveStatus ? Colors.green : Colors.grey,
-                            borderRadius: AppStyle.radius12,
-                          ),
-                        ),
-                        AppStyle.hGap4,
-                        Text(
-                          item.liveStatus ? "直播中" : "未开播",
-                          style: TextStyle(
-                            fontSize: 12,
-                            fontWeight: FontWeight.normal,
-                            color: item.liveStatus ? null : Colors.grey,
-                          ),
-                        ),
-                      ],
+                  )
+                : Align(
+                    alignment: Alignment.topCenter,
+                    child: SizedBox(
+                      width: anchorViewportWidth,
+                      child: PageGridView(
+                        pageController: controller,
+                        padding: EdgeInsets.fromLTRB(gutter, 20, gutter, 24),
+                        firstRefresh: true,
+                        mainAxisSpacing: anchorSpacing,
+                        crossAxisSpacing: anchorSpacing,
+                        crossAxisCount: anchorColumnCount,
+                        itemBuilder: (_, i) {
+                          final item = controller.list[i] as LiveAnchorItem;
+                          return _AnchorResultCard(
+                            item: item,
+                            onTap: () {
+                              AppNavigator.toLiveRoomDetail(
+                                site: controller.site,
+                                roomId: item.roomId,
+                              );
+                            },
+                          );
+                        },
+                      ),
                     ),
-                    onTap: () {
-                      AppNavigator.toLiveRoomDetail(
-                          site: controller.site, roomId: item.roomId);
-                    },
-                  );
-                },
-              ),
+                  ),
+          );
+        },
+      ),
+    );
+  }
+
+  double _contentGutter(double width) {
+    if (width >= 1200) return 32;
+    if (width >= 720) return 24;
+    return 12;
+  }
+}
+
+class _AnchorResultCard extends StatelessWidget {
+  const _AnchorResultCard({
+    required this.item,
+    required this.onTap,
+  });
+
+  final LiveAnchorItem item;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final semantic = context.appTheme;
+    final statusColor =
+        item.liveStatus ? theme.colorScheme.tertiary : semantic.textDisabled;
+
+    return ShadowCard(
+      onTap: onTap,
+      child: ConstrainedBox(
+        constraints: const BoxConstraints(minHeight: 82),
+        child: ListTile(
+          contentPadding: const EdgeInsets.symmetric(
+            horizontal: AppDesignTokens.space12,
+            vertical: AppDesignTokens.space8,
+          ),
+          leading: NetImage(
+            item.avatar,
+            width: 52,
+            height: 52,
+            borderRadius: 26,
+          ),
+          title: Text(
+            item.userName,
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
+            style: theme.textTheme.titleSmall?.copyWith(
+              color: semantic.textPrimary,
+              fontWeight: FontWeight.w700,
+            ),
+          ),
+          subtitle: Padding(
+            padding: const EdgeInsets.only(top: AppDesignTokens.space4),
+            child: Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Container(
+                  width: 8,
+                  height: 8,
+                  decoration: BoxDecoration(
+                    color: statusColor,
+                    shape: BoxShape.circle,
+                  ),
+                ),
+                const SizedBox(width: AppDesignTokens.space8),
+                Flexible(
+                  child: Text(
+                    item.liveStatus ? '直播中' : '未开播',
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                    style: theme.textTheme.bodySmall?.copyWith(
+                      color: item.liveStatus
+                          ? semantic.textSecondary
+                          : semantic.textTertiary,
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+          trailing: Icon(
+            Icons.chevron_right_rounded,
+            color: semantic.textTertiary,
+          ),
+        ),
       ),
     );
   }

--- a/simple_live_app/lib/modules/search/search_page.dart
+++ b/simple_live_app/lib/modules/search/search_page.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
-import 'package:simple_live_app/app/app_style.dart';
+import 'package:simple_live_app/app/design_system/app_design_tokens.dart';
+import 'package:simple_live_app/app/design_system/app_theme_extension.dart';
 import 'package:simple_live_app/app/sites.dart';
 import 'package:simple_live_app/modules/search/search_controller.dart';
 import 'package:simple_live_app/modules/search/search_list_view.dart';
@@ -10,97 +11,185 @@ class SearchPage extends GetView<AppSearchController> {
 
   @override
   Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final semantic = context.appTheme;
+    final searchRadius = BorderRadius.circular(24);
+
     return Scaffold(
       appBar: AppBar(
         automaticallyImplyLeading: false,
-        title: TextField(
-          controller: controller.searchController,
-          autofocus: true,
-          decoration: InputDecoration(
-            hintText: "搜点什么吧",
-            border: OutlineInputBorder(
-              borderRadius: AppStyle.radius24,
-            ),
-            contentPadding: AppStyle.edgeInsetsH12,
-            prefixIcon: Row(
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                IconButton(
-                  onPressed: Get.back,
-                  icon: const Icon(Icons.arrow_back),
+        centerTitle: false,
+        leadingWidth: 52,
+        leading: IconButton(
+          onPressed: Get.back,
+          tooltip: '返回',
+          icon: const Icon(Icons.arrow_back_rounded),
+        ),
+        titleSpacing: 0,
+        toolbarHeight: 68,
+        title: Padding(
+          padding: const EdgeInsets.only(right: AppDesignTokens.space12),
+          child: SizedBox(
+            height: 48,
+            child: TextField(
+              controller: controller.searchController,
+              autofocus: true,
+              textInputAction: TextInputAction.search,
+              decoration: InputDecoration(
+                hintText: '搜索直播间或主播',
+                isDense: true,
+                filled: true,
+                fillColor: semantic.secondarySurface,
+                contentPadding: const EdgeInsets.symmetric(
+                  horizontal: AppDesignTokens.space12,
                 ),
-                Obx(
-                  () => DropdownButton<int>(
-                    underline: const SizedBox(),
-                    items: const [
-                      DropdownMenuItem(
-                        value: 0,
-                        child: Text("房间"),
-                      ),
-                      DropdownMenuItem(
-                        value: 1,
-                        child: Text("主播"),
-                      ),
-                    ],
-                    value: controller.searchMode.value,
-                    onChanged: (e) {
-                      controller.searchMode.value = e ?? 0;
-                      controller.doSearch();
-                    },
+                prefixIcon: Icon(
+                  Icons.search_rounded,
+                  color: semantic.textTertiary,
+                  size: 20,
+                ),
+                suffixIcon: IconButton(
+                  onPressed: controller.doSearch,
+                  tooltip: '搜索',
+                  icon: const Icon(Icons.arrow_forward_rounded, size: 20),
+                ),
+                border: OutlineInputBorder(
+                  borderRadius: searchRadius,
+                  borderSide: BorderSide(color: semantic.border),
+                ),
+                enabledBorder: OutlineInputBorder(
+                  borderRadius: searchRadius,
+                  borderSide: BorderSide(color: semantic.border),
+                ),
+                focusedBorder: OutlineInputBorder(
+                  borderRadius: searchRadius,
+                  borderSide: BorderSide(
+                    color: theme.colorScheme.primary,
+                    width: 1.5,
                   ),
                 ),
-                AppStyle.hGap8,
-              ],
-            ),
-            suffixIcon: IconButton(
-              onPressed: controller.doSearch,
-              icon: const Icon(Icons.search),
+              ),
+              onSubmitted: (_) => controller.doSearch(),
             ),
           ),
-          onSubmitted: (e) {
-            controller.doSearch();
-          },
         ),
-        bottom: TabBar(
-          controller: controller.tabController,
-          padding: EdgeInsets.zero,
-          tabAlignment: TabAlignment.center,
-          tabs: Sites.supportSites
-              .map(
-                (e) => Tab(
-                  //text: e.name,
-                  child: Row(
-                    children: [
-                      Image.asset(
-                        e.logo,
-                        width: 24,
+        bottom: PreferredSize(
+          preferredSize: const Size.fromHeight(52),
+          child: DecoratedBox(
+            decoration: BoxDecoration(
+              border: Border(
+                bottom: BorderSide(color: semantic.border),
+              ),
+            ),
+            child: SizedBox(
+              height: 52,
+              child: Row(
+                children: [
+                  const SizedBox(width: AppDesignTokens.space12),
+                  Obx(
+                    () => Container(
+                      height: 40,
+                      padding: const EdgeInsets.only(
+                        left: AppDesignTokens.space12,
+                        right: AppDesignTokens.space8,
                       ),
-                      AppStyle.hGap8,
-                      Text(e.name),
-                    ],
+                      decoration: BoxDecoration(
+                        color: semantic.secondarySurface,
+                        borderRadius: BorderRadius.circular(
+                          AppDesignTokens.radius10,
+                        ),
+                        border: Border.all(color: semantic.border),
+                      ),
+                      child: DropdownButtonHideUnderline(
+                        child: DropdownButton<int>(
+                          value: controller.searchMode.value,
+                          isDense: true,
+                          borderRadius: BorderRadius.circular(
+                            AppDesignTokens.radius10,
+                          ),
+                          dropdownColor: semantic.elevatedSurface,
+                          icon: const Icon(
+                            Icons.keyboard_arrow_down_rounded,
+                            size: 18,
+                          ),
+                          style: theme.textTheme.labelMedium?.copyWith(
+                            color: semantic.textPrimary,
+                            fontWeight: FontWeight.w600,
+                          ),
+                          items: const [
+                            DropdownMenuItem(
+                              value: 0,
+                              child: Text('房间'),
+                            ),
+                            DropdownMenuItem(
+                              value: 1,
+                              child: Text('主播'),
+                            ),
+                          ],
+                          onChanged: (value) {
+                            controller.searchMode.value = value ?? 0;
+                            controller.doSearch();
+                          },
+                        ),
+                      ),
+                    ),
                   ),
-                ),
-              )
-              .toList(),
-          labelPadding: AppStyle.edgeInsetsH20,
-          isScrollable: true,
-          indicatorSize: TabBarIndicatorSize.label,
+                  const SizedBox(width: AppDesignTokens.space8),
+                  Expanded(
+                    child: TabBar(
+                      controller: controller.tabController,
+                      isScrollable: true,
+                      tabAlignment: TabAlignment.start,
+                      indicatorSize: TabBarIndicatorSize.label,
+                      labelPadding: const EdgeInsets.symmetric(
+                        horizontal: AppDesignTokens.space12,
+                      ),
+                      tabs: Sites.supportSites.map(_SiteTab.new).toList(),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
         ),
       ),
       body: TabBarView(
         physics: const NeverScrollableScrollPhysics(),
         controller: controller.tabController,
         children: Sites.supportSites
-            .map((e) => SearchListView(
-                      e.id,
-                    )
-                // (e) => e.id == Constant.kDouyin
-                //     ? const DouyinSearchView()
-                //     : SearchListView(
-                //         e.id,
-                //       ),
-                )
+            .map(
+              (site) => SearchListView(site.id),
+            )
             .toList(),
+      ),
+    );
+  }
+}
+
+class _SiteTab extends StatelessWidget {
+  const _SiteTab(this.site);
+
+  final Site site;
+
+  @override
+  Widget build(BuildContext context) {
+    return Tab(
+      height: 40,
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Image.asset(
+            site.logo,
+            width: 18,
+            height: 18,
+          ),
+          const SizedBox(width: AppDesignTokens.space8),
+          Text(
+            site.name,
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
+          ),
+        ],
       ),
     );
   }

--- a/simple_live_app/lib/modules/settings/appstyle_settings/appstyle_setting_contorller.dart
+++ b/simple_live_app/lib/modules/settings/appstyle_settings/appstyle_setting_contorller.dart
@@ -11,6 +11,7 @@ import 'package:get/get_rx/src/rx_types/rx_types.dart';
 import 'package:get/get_state_manager/src/simple/get_controllers.dart';
 import 'package:path_provider/path_provider.dart';
 import 'package:simple_live_app/app/constant.dart';
+import 'package:simple_live_app/app/design_system/app_design_tokens.dart';
 import 'package:simple_live_app/app/log.dart';
 import 'package:simple_live_app/models/font_model.dart';
 import 'package:simple_live_app/requests/http_client.dart';
@@ -22,7 +23,7 @@ class AppStyleSettingController extends GetxController {
 
   var themeMode = 0.obs;
   var isDynamic = false.obs;
-  var styleColor = 0xff3498db.obs;
+  var styleColor = AppDesignTokens.defaultSeedValue.obs;
   Rx<String?> curFontName = Rx<String?>(null);
   Rx<FontModel?> curFontModel = Rx<FontModel?>(null);
   final RxList<FontModel> fontList = <FontModel>[].obs;
@@ -31,8 +32,10 @@ class AppStyleSettingController extends GetxController {
 
 
   Future<void> init() async {
-    styleColor.value = LocalStorageService.instance
-        .getValue(LocalStorageService.kStyleColor, 0xff3498db);
+    styleColor.value = LocalStorageService.instance.getValue(
+      LocalStorageService.kStyleColor,
+      AppDesignTokens.defaultSeedValue,
+    );
 
     isDynamic.value = LocalStorageService.instance
         .getValue(LocalStorageService.kIsDynamic, false);

--- a/simple_live_app/lib/modules/settings/appstyle_settings/appstyle_setting_page.dart
+++ b/simple_live_app/lib/modules/settings/appstyle_settings/appstyle_setting_page.dart
@@ -2,6 +2,8 @@ import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import 'package:simple_live_app/app/app_style.dart';
 import 'package:simple_live_app/app/constant.dart';
+import 'package:simple_live_app/app/design_system/app_design_tokens.dart';
+import 'package:simple_live_app/app/design_system/app_theme_extension.dart';
 import 'package:simple_live_app/modules/settings/appstyle_settings/appstyle_setting_contorller.dart';
 import 'package:simple_live_app/widgets/settings/settings_card.dart';
 import 'package:simple_live_app/widgets/settings/settings_menu.dart';
@@ -10,34 +12,22 @@ import 'package:simple_live_app/widgets/settings/settings_switch.dart';
 class AppStyleSettingPage extends GetView<AppStyleSettingController> {
   const AppStyleSettingPage({super.key});
 
-  Widget trailingBuild({required Widget widget}) {
+  Widget _fontActions({required Widget primaryAction}) {
     return Row(
       mainAxisSize: MainAxisSize.min,
       children: [
-        Tooltip(
-          message: "重置为默认字体",
-          child: IconButton(
-            onPressed: controller.fontReset,
-            icon: Icon(Icons.settings_backup_restore_outlined),
-          ),
+        IconButton(
+          onPressed: controller.fontReset,
+          tooltip: '重置为默认字体',
+          icon: const Icon(Icons.settings_backup_restore_outlined),
         ),
-        AppStyle.hGap4,
-        Visibility(
-          visible: controller.fontState.value == DownloadState.downloaded,
-          child:
-        Tooltip(
-          message: "删除字体",
-          child: IconButton(
+        if (controller.fontState.value == DownloadState.downloaded)
+          IconButton(
             onPressed: controller.fontDelete,
-            icon: Icon(Icons.delete_outline_outlined),
+            tooltip: '删除字体',
+            icon: const Icon(Icons.delete_outline_outlined),
           ),
-        ),
-        ),
-        Visibility(
-          visible: controller.fontState.value == DownloadState.downloaded,
-          child: AppStyle.hGap4,
-        ),
-        widget,
+        primaryAction,
       ],
     );
   }
@@ -45,188 +35,209 @@ class AppStyleSettingPage extends GetView<AppStyleSettingController> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(
-        title: const Text("外观设置"),
-      ),
-      body: ListView(
-        padding: AppStyle.edgeInsetsA12,
-        children: [
-          Padding(
-            padding: AppStyle.edgeInsetsA12.copyWith(top: 0),
-            child: Text(
-              "显示主题",
-              style: Get.textTheme.titleSmall,
-            ),
-          ),
-          SettingsCard(
-            child: Obx(
-              () => RadioGroup<int>(
-                groupValue: controller.themeMode.value,
-                onChanged: (e) {
-                  controller.setTheme(e ?? 0);
-                },
-                child: Column(
-                  mainAxisSize: MainAxisSize.min,
-                  children: [
-                    RadioListTile<int>(
-                      title: const Text(
-                        "跟随系统",
-                      ),
-                      visualDensity: VisualDensity.compact,
-                      value: 0,
-                      contentPadding: AppStyle.edgeInsetsH12,
+      appBar: AppBar(title: const Text('外观设置')),
+      body: Align(
+        alignment: Alignment.topCenter,
+        child: ConstrainedBox(
+          constraints: const BoxConstraints(maxWidth: 800),
+          child: ListView(
+            padding: const EdgeInsets.fromLTRB(16, 12, 16, 32),
+            children: [
+              const _SectionHeading(title: '显示主题'),
+              SettingsCard(
+                child: Obx(
+                  () => RadioGroup<int>(
+                    groupValue: controller.themeMode.value,
+                    onChanged: (value) => controller.setTheme(value ?? 0),
+                    child: Column(
+                      mainAxisSize: MainAxisSize.min,
+                      children: const [
+                        RadioListTile<int>(
+                          title: Text('跟随系统'),
+                          visualDensity: VisualDensity.compact,
+                          value: 0,
+                          contentPadding: EdgeInsets.symmetric(horizontal: 12),
+                        ),
+                        RadioListTile<int>(
+                          title: Text('浅色模式'),
+                          visualDensity: VisualDensity.compact,
+                          value: 1,
+                          contentPadding: EdgeInsets.symmetric(horizontal: 12),
+                        ),
+                        RadioListTile<int>(
+                          title: Text('深色模式'),
+                          visualDensity: VisualDensity.compact,
+                          value: 2,
+                          contentPadding: EdgeInsets.symmetric(horizontal: 12),
+                        ),
+                      ],
                     ),
-                    RadioListTile<int>(
-                      title: const Text(
-                        "浅色模式",
-                      ),
-                      visualDensity: VisualDensity.compact,
-                      value: 1,
-                      contentPadding: AppStyle.edgeInsetsH12,
-                    ),
-                    RadioListTile<int>(
-                      title: const Text(
-                        "深色模式",
-                      ),
-                      visualDensity: VisualDensity.compact,
-                      value: 2,
-                      contentPadding: AppStyle.edgeInsetsH12,
-                    ),
-                  ],
+                  ),
                 ),
               ),
-            ),
-          ),
-          AppStyle.vGap12,
-          Padding(
-            padding: AppStyle.edgeInsetsA12,
-            child: Text(
-              "主题颜色",
-              style: Get.textTheme.titleSmall,
-            ),
-          ),
-          SettingsCard(
-            child: Obx(
-              () => Column(
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  SettingsSwitch(
-                    value: controller.isDynamic.value,
-                    title: "动态取色",
-                    onChanged: (e) {
-                      controller.setIsDynamic(e);
-                      Get.forceAppUpdate();
-                    },
-                  ),
-                  if (!controller.isDynamic.value) AppStyle.divider,
-                  if (!controller.isDynamic.value)
-                    Padding(
-                      padding: AppStyle.edgeInsetsA12,
-                      child: Wrap(
-                        spacing: 8,
-                        runSpacing: 8,
-                        children: <Color>[
-                          const Color(0xffEF5350),
-                          const Color(0xff3498db),
-                          const Color(0xffF06292),
-                          const Color(0xff9575CD),
-                          const Color(0xff26C6DA),
-                          const Color(0xff26A69A),
-                          const Color(0xffFFF176),
-                          const Color(0xffFF9800),
-                        ]
-                            .map(
-                              (e) => GestureDetector(
-                                onTap: () {
-                                  controller.setStyleColor(e.v);
-                                  Get.forceAppUpdate();
-                                },
-                                child: Container(
-                                  width: 36,
-                                  height: 36,
-                                  decoration: BoxDecoration(
-                                    color: e,
-                                    borderRadius: AppStyle.radius4,
-                                    border: Border.all(
-                                      color: Colors.grey.withAlpha(50),
-                                      width: 1,
+              const _SectionHeading(title: '主题颜色', top: 24),
+              SettingsCard(
+                child: Obx(
+                  () => Column(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      SettingsSwitch(
+                        value: controller.isDynamic.value,
+                        title: '动态取色',
+                        subtitle: '使用系统提供的动态配色方案',
+                        onChanged: (value) {
+                          controller.setIsDynamic(value);
+                          Get.forceAppUpdate();
+                        },
+                      ),
+                      if (!controller.isDynamic.value) AppStyle.divider,
+                      if (!controller.isDynamic.value)
+                        Padding(
+                          padding: const EdgeInsets.all(AppDesignTokens.space16),
+                          child: Align(
+                            alignment: Alignment.centerLeft,
+                            child: Wrap(
+                              spacing: AppDesignTokens.space12,
+                              runSpacing: AppDesignTokens.space12,
+                              children: <Color>[
+                                const Color(0xffEF5350),
+                                const Color(0xff3498DB),
+                                AppColors.defaultSeedColor,
+                                const Color(0xffF06292),
+                                const Color(0xff9575CD),
+                                const Color(0xff26C6DA),
+                                const Color(0xff26A69A),
+                                const Color(0xffFFF176),
+                                const Color(0xffFF9800),
+                              ].map((color) {
+                                final selected =
+                                    controller.styleColor.value == color.v;
+                                final brightness =
+                                    ThemeData.estimateBrightnessForColor(color);
+                                final foreground = ColorScheme.fromSeed(
+                                  seedColor: color,
+                                  brightness: brightness,
+                                ).onPrimary;
+                                return Semantics(
+                                  button: true,
+                                  selected: selected,
+                                  label: '选择主题颜色',
+                                  child: InkWell(
+                                    onTap: () {
+                                      controller.setStyleColor(color.v);
+                                      Get.forceAppUpdate();
+                                    },
+                                    borderRadius: BorderRadius.circular(
+                                      AppDesignTokens.radius12,
+                                    ),
+                                    child: AnimatedContainer(
+                                      duration:
+                                          const Duration(milliseconds: 160),
+                                      width: 44,
+                                      height: 44,
+                                      decoration: BoxDecoration(
+                                        color: color,
+                                        borderRadius: BorderRadius.circular(
+                                          AppDesignTokens.radius12,
+                                        ),
+                                        border: Border.all(
+                                          color: selected
+                                              ? foreground
+                                              : context.appTheme.border,
+                                          width: selected ? 2 : 1,
+                                        ),
+                                      ),
+                                      child: selected
+                                          ? Icon(
+                                              Icons.check_rounded,
+                                              color: foreground,
+                                            )
+                                          : null,
                                     ),
                                   ),
-                                  child: Obx(
-                                    () => Center(
-                                      child: Icon(
-                                        Icons.check,
-                                        color:
-                                            controller.styleColor.value == e.v
-                                                ? Colors.white
-                                                : Colors.transparent,
-                                      ),
-                                    ),
+                                );
+                              }).toList(),
+                            ),
+                          ),
+                        ),
+                    ],
+                  ),
+                ),
+              ),
+              const _SectionHeading(title: '字体设置', top: 24),
+              SettingsCard(
+                child: Obx(
+                  () => SettingsMenu(
+                    title: controller.curFontModel.value!.name,
+                    value: controller.curFontModel.value!,
+                    valueMap: controller.fontMap,
+                    onChanged: controller.onFontSelected,
+                    trailing: Obx(() {
+                      switch (controller.fontState.value) {
+                        case DownloadState.notDownloaded:
+                          return _fontActions(
+                            primaryAction: IconButton(
+                              tooltip: '下载字体',
+                              icon: const Icon(Icons.download_outlined),
+                              onPressed: controller.downloadFont,
+                            ),
+                          );
+                        case DownloadState.downloading:
+                          return _fontActions(
+                            primaryAction: const SizedBox(
+                              width: 44,
+                              height: 44,
+                              child: Center(
+                                child: SizedBox(
+                                  width: 20,
+                                  height: 20,
+                                  child: CircularProgressIndicator(
+                                    strokeWidth: 2,
                                   ),
                                 ),
                               ),
-                            )
-                            .toList(),
-                      ),
-                    ),
-                ],
+                            ),
+                          );
+                        case DownloadState.downloaded:
+                          return _fontActions(
+                            primaryAction: IconButton(
+                              tooltip: '应用字体',
+                              icon: const Icon(
+                                Icons.check_circle_outline_outlined,
+                              ),
+                              onPressed: controller.changeFontFamily,
+                            ),
+                          );
+                      }
+                    }),
+                  ),
+                ),
               ),
-            ),
+            ],
           ),
-          AppStyle.vGap12,
-          Padding(
-            padding: AppStyle.edgeInsetsA12,
-            child: Text(
-              "字体设置",
-              style: Get.textTheme.titleSmall,
-            ),
-          ),
-          SettingsCard(
-            child: Obx(
-              () => SettingsMenu(
-                title: controller.curFontModel.value!.name,
-                value: controller.curFontModel.value!,
-                valueMap: controller.fontMap,
-                onChanged: (e) {
-                  controller.onFontSelected(e);
-                },
-                trailing: Obx(() {
-                  switch (controller.fontState.value) {
-                    case DownloadState.notDownloaded:
-                      return trailingBuild(
-                        widget: Tooltip(
-                          message: "下载字体",
-                          child: IconButton(
-                            icon: const Icon(Icons.download_outlined),
-                            onPressed: () => controller.downloadFont(),
-                          ),
-                        ),
-                      );
+        ),
+      ),
+    );
+  }
+}
 
-                    case DownloadState.downloading:
-                      return trailingBuild(
-                        widget: SizedBox(
-                          width: 20,
-                          height: 20,
-                          child: CircularProgressIndicator(strokeWidth: 2),
-                        ),
-                      );
-                    case DownloadState.downloaded:
-                      return trailingBuild(
-                        widget: Tooltip(
-                          message: "应用字体",
-                          child: IconButton(
-                            icon: const Icon(Icons.check_circle_outline_outlined),
-                            onPressed: () => controller.changeFontFamily(),
-                          ),
-                        ),
-                      );
-                  }
-                }),
-              ),
-            ),
-          ),
-        ],
+class _SectionHeading extends StatelessWidget {
+  const _SectionHeading({required this.title, this.top = 0});
+
+  final String title;
+  final double top;
+
+  @override
+  Widget build(BuildContext context) {
+    final semantic = context.appTheme;
+    return Padding(
+      padding: EdgeInsets.fromLTRB(4, top, 4, AppDesignTokens.space8),
+      child: Text(
+        title,
+        style: Theme.of(context).textTheme.titleSmall?.copyWith(
+          color: semantic.textSecondary,
+          fontWeight: FontWeight.w700,
+        ),
       ),
     );
   }
@@ -241,5 +252,5 @@ extension ColorExt on Color {
       _floatToInt8(a) << 24 |
       _floatToInt8(r) << 16 |
       _floatToInt8(g) << 8 |
-      _floatToInt8(b) << 0;
+      _floatToInt8(b);
 }

--- a/simple_live_app/lib/modules/settings/auto_exit_settings_page.dart
+++ b/simple_live_app/lib/modules/settings/auto_exit_settings_page.dart
@@ -2,6 +2,8 @@ import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import 'package:simple_live_app/app/app_style.dart';
 import 'package:simple_live_app/app/controller/app_settings_controller.dart';
+import 'package:simple_live_app/app/design_system/app_design_tokens.dart';
+import 'package:simple_live_app/app/design_system/app_theme_extension.dart';
 import 'package:simple_live_app/widgets/settings/settings_action.dart';
 import 'package:simple_live_app/widgets/settings/settings_card.dart';
 import 'package:simple_live_app/widgets/settings/settings_switch.dart';
@@ -12,54 +14,56 @@ class AutoExitSettingsPage extends GetView<AppSettingsController> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(
-        title: const Text("定时关闭设置"),
-      ),
-      body: ListView(
-        padding: AppStyle.edgeInsetsA12,
-        children: [
-          SettingsCard(
-            child: Column(
-              children: [
-                Obx(
-                  () => SettingsSwitch(
-                    value: controller.autoExitEnable.value,
-                    title: "启用定时关闭",
-                    onChanged: (e) {
-                      controller.setAutoExitEnable(e);
-                    },
-                  ),
-                ),
-                Obx(
-                  () => Visibility(
-                    visible: controller.autoExitEnable.value,
-                    child: AppStyle.divider,
-                  ),
-                ),
-                Obx(
-                  () => Visibility(
-                    visible: controller.autoExitEnable.value,
-                    child: SettingsAction(
-                      title: "自动关闭时间",
-                      value:
-                          "${controller.autoExitDuration.value ~/ 60}小时${controller.autoExitDuration.value % 60}分钟",
-                      subtitle: "从进入直播间开始倒计时",
-                      onTap: () {
-                        setTimer(context);
-                      },
+      appBar: AppBar(title: const Text('定时关闭设置')),
+      body: Align(
+        alignment: Alignment.topCenter,
+        child: ConstrainedBox(
+          constraints: const BoxConstraints(maxWidth: 760),
+          child: ListView(
+            padding: const EdgeInsets.fromLTRB(16, 12, 16, 32),
+            children: [
+              const _SectionHeading(title: '自动关闭'),
+              SettingsCard(
+                child: Column(
+                  children: [
+                    Obx(
+                      () => SettingsSwitch(
+                        value: controller.autoExitEnable.value,
+                        title: '启用定时关闭',
+                        subtitle: '进入直播间后开始计时',
+                        onChanged: controller.setAutoExitEnable,
+                      ),
                     ),
-                  ),
+                    Obx(
+                      () => Visibility(
+                        visible: controller.autoExitEnable.value,
+                        child: AppStyle.divider,
+                      ),
+                    ),
+                    Obx(
+                      () => Visibility(
+                        visible: controller.autoExitEnable.value,
+                        child: SettingsAction(
+                          title: '自动关闭时间',
+                          value:
+                              '${controller.autoExitDuration.value ~/ 60}小时${controller.autoExitDuration.value % 60}分钟',
+                          subtitle: '从进入直播间开始倒计时',
+                          onTap: () => setTimer(context),
+                        ),
+                      ),
+                    ),
+                  ],
                 ),
-              ],
-            ),
+              ),
+            ],
           ),
-        ],
+        ),
       ),
     );
   }
 
   void setTimer(BuildContext context) async {
-    var value = await showTimePicker(
+    final value = await showTimePicker(
       context: context,
       initialTime: TimeOfDay(
         hour: controller.autoExitDuration.value ~/ 60,
@@ -68,17 +72,34 @@ class AutoExitSettingsPage extends GetView<AppSettingsController> {
       initialEntryMode: TimePickerEntryMode.inputOnly,
       builder: (_, child) {
         return MediaQuery(
-          data: MediaQuery.of(context).copyWith(
-            alwaysUse24HourFormat: true,
-          ),
+          data: MediaQuery.of(context).copyWith(alwaysUse24HourFormat: true),
           child: child!,
         );
       },
     );
-    if (value == null || (value.hour == 0 && value.minute == 0)) {
-      return;
-    }
-    var duration = Duration(hours: value.hour, minutes: value.minute);
+    if (value == null || (value.hour == 0 && value.minute == 0)) return;
+    final duration = Duration(hours: value.hour, minutes: value.minute);
     controller.setAutoExitDuration(duration.inMinutes);
+  }
+}
+
+class _SectionHeading extends StatelessWidget {
+  const _SectionHeading({required this.title});
+
+  final String title;
+
+  @override
+  Widget build(BuildContext context) {
+    final semantic = context.appTheme;
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(4, 0, 4, AppDesignTokens.space8),
+      child: Text(
+        title,
+        style: Theme.of(context).textTheme.titleSmall?.copyWith(
+          color: semantic.textSecondary,
+          fontWeight: FontWeight.w700,
+        ),
+      ),
+    );
   }
 }

--- a/simple_live_app/lib/modules/settings/danmu_settings_page.dart
+++ b/simple_live_app/lib/modules/settings/danmu_settings_page.dart
@@ -18,11 +18,17 @@ class DanmuSettingsPage extends StatelessWidget {
       appBar: AppBar(
         title: const Text("弹幕设置"),
       ),
-      body: ListView(
-        padding: AppStyle.edgeInsetsA12,
-        children: const [
-          DanmuSettingsView(),
-        ],
+      body: Align(
+        alignment: Alignment.topCenter,
+        child: ConstrainedBox(
+          constraints: const BoxConstraints(maxWidth: 800),
+          child: ListView(
+            padding: const EdgeInsets.fromLTRB(16, 12, 16, 32),
+            children: const [
+              DanmuSettingsView(),
+            ],
+          ),
+        ),
       ),
     );
   }

--- a/simple_live_app/lib/modules/settings/danmu_shield/danmu_shield_page.dart
+++ b/simple_live_app/lib/modules/settings/danmu_shield/danmu_shield_page.dart
@@ -1,79 +1,152 @@
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
-import 'package:simple_live_app/app/app_style.dart';
+import 'package:simple_live_app/app/design_system/app_design_tokens.dart';
+import 'package:simple_live_app/app/design_system/app_theme_extension.dart';
 import 'package:simple_live_app/modules/settings/danmu_shield/danmu_shield_controller.dart';
+import 'package:simple_live_app/widgets/settings/settings_card.dart';
 
 class DanmuShieldPage extends GetView<DanmuShieldController> {
   const DanmuShieldPage({super.key});
 
   @override
   Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final semantic = context.appTheme;
+
     return Scaffold(
-      appBar: AppBar(
-        title: const Text("弹幕屏蔽"),
-      ),
-      body: ListView(
-        padding: AppStyle.edgeInsetsA12,
-        children: [
-          TextField(
-            controller: controller.textEditingController,
-            decoration: InputDecoration(
-              contentPadding: AppStyle.edgeInsetsH12,
-              border: const OutlineInputBorder(),
-              hintText: "请输入关键词或正则表达式",
-              suffixIcon: TextButton.icon(
-                onPressed: controller.add,
-                icon: const Icon(Icons.add),
-                label: const Text("添加"),
-              ),
-            ),
-            onSubmitted: (e) {
-              controller.add();
-            },
-          ),
-          AppStyle.vGap4,
-          Text(
-            '以"/"开头和结尾将视作正则表达式, 如"/\\d+/"表示屏蔽所有数字',
-            style: Get.textTheme.bodySmall,
-          ),
-          AppStyle.vGap12,
-          Obx(
-            () => Text(
-              "已添加${controller.settingsController.shieldList.length}个关键词（点击移除）",
-              style: Get.textTheme.titleSmall,
-            ),
-          ),
-          AppStyle.vGap12,
-          Obx(
-            () => Wrap(
-              runSpacing: 12,
-              spacing: 12,
-              children: controller.settingsController.shieldList
-                  .map(
-                    (item) => InkWell(
-                      borderRadius: AppStyle.radius24,
-                      onTap: () {
-                        controller.remove(item);
-                      },
-                      child: Container(
-                        decoration: BoxDecoration(
-                          border: Border.all(color: Colors.grey),
-                          borderRadius: AppStyle.radius24,
+      appBar: AppBar(title: const Text('弹幕屏蔽')),
+      body: Align(
+        alignment: Alignment.topCenter,
+        child: ConstrainedBox(
+          constraints: const BoxConstraints(maxWidth: 800),
+          child: ListView(
+            padding: const EdgeInsets.fromLTRB(16, 12, 16, 32),
+            children: [
+              const _SectionHeading(title: '添加屏蔽规则'),
+              SettingsCard(
+                child: Padding(
+                  padding: const EdgeInsets.all(AppDesignTokens.space16),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.stretch,
+                    children: [
+                      TextField(
+                        controller: controller.textEditingController,
+                        decoration: const InputDecoration(
+                          border: OutlineInputBorder(),
+                          hintText: '请输入关键词或正则表达式',
+                          prefixIcon: Icon(Icons.block_rounded),
                         ),
-                        padding: AppStyle.edgeInsetsH12.copyWith(
-                          top: 4,
-                          bottom: 4,
-                        ),
-                        child: Text(
-                          item,
-                          style: Get.textTheme.bodyMedium,
+                        onSubmitted: (_) => controller.add(),
+                      ),
+                      const SizedBox(height: AppDesignTokens.space12),
+                      FilledButton.icon(
+                        onPressed: controller.add,
+                        icon: const Icon(Icons.add_rounded),
+                        label: const Text('添加规则'),
+                      ),
+                      const SizedBox(height: AppDesignTokens.space8),
+                      Text(
+                        '以“/”开头和结尾将视作正则表达式，例如“/\\d+/”表示屏蔽所有数字。',
+                        style: theme.textTheme.bodySmall?.copyWith(
+                          color: semantic.textSecondary,
                         ),
                       ),
-                    ),
-                  )
-                  .toList(),
+                    ],
+                  ),
+                ),
+              ),
+              Obx(
+                () => _SectionHeading(
+                  title:
+                      '已添加 ${controller.settingsController.shieldList.length} 个规则',
+                  subtitle: '点击删除图标移除规则',
+                  top: 24,
+                ),
+              ),
+              SettingsCard(
+                child: Obx(
+                  () => Padding(
+                    padding: const EdgeInsets.all(AppDesignTokens.space16),
+                    child: controller.settingsController.shieldList.isEmpty
+                        ? Padding(
+                            padding: const EdgeInsets.symmetric(vertical: 24),
+                            child: Text(
+                              '暂无屏蔽规则',
+                              textAlign: TextAlign.center,
+                              style: theme.textTheme.bodyMedium?.copyWith(
+                                color: semantic.textTertiary,
+                              ),
+                            ),
+                          )
+                        : Wrap(
+                            runSpacing: AppDesignTokens.space8,
+                            spacing: AppDesignTokens.space8,
+                            children: controller.settingsController.shieldList
+                                .map(
+                                  (item) => ConstrainedBox(
+                                    constraints: const BoxConstraints(
+                                      maxWidth: 680,
+                                    ),
+                                    child: InputChip(
+                                      label: Text(
+                                        item,
+                                        maxLines: 1,
+                                        overflow: TextOverflow.ellipsis,
+                                      ),
+                                      deleteButtonTooltipMessage: '移除 $item',
+                                      onDeleted: () => controller.remove(item),
+                                    ),
+                                  ),
+                                )
+                                .toList(),
+                          ),
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _SectionHeading extends StatelessWidget {
+  const _SectionHeading({
+    required this.title,
+    this.subtitle,
+    this.top = 0,
+  });
+
+  final String title;
+  final String? subtitle;
+  final double top;
+
+  @override
+  Widget build(BuildContext context) {
+    final semantic = context.appTheme;
+    final theme = Theme.of(context);
+    return Padding(
+      padding: EdgeInsets.fromLTRB(4, top, 4, AppDesignTokens.space8),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            title,
+            style: theme.textTheme.titleSmall?.copyWith(
+              color: semantic.textSecondary,
+              fontWeight: FontWeight.w700,
             ),
           ),
+          if (subtitle != null) ...[
+            const SizedBox(height: 2),
+            Text(
+              subtitle!,
+              style: theme.textTheme.bodySmall?.copyWith(
+                color: semantic.textTertiary,
+              ),
+            ),
+          ],
         ],
       ),
     );

--- a/simple_live_app/lib/modules/settings/indexed_settings/indexed_settings_page.dart
+++ b/simple_live_app/lib/modules/settings/indexed_settings/indexed_settings_page.dart
@@ -1,7 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
-import 'package:simple_live_app/app/app_style.dart';
 import 'package:simple_live_app/app/constant.dart';
+import 'package:simple_live_app/app/design_system/app_design_tokens.dart';
+import 'package:simple_live_app/app/design_system/app_theme_extension.dart';
 import 'package:simple_live_app/app/sites.dart';
 import 'package:simple_live_app/modules/settings/indexed_settings/indexed_settings_controller.dart';
 import 'package:simple_live_app/widgets/settings/settings_card.dart';
@@ -12,72 +13,135 @@ class IndexedSettingsPage extends GetView<IndexedSettingsController> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(
-        title: const Text("主页设置"),
+      appBar: AppBar(title: const Text('主页设置')),
+      body: Align(
+        alignment: Alignment.topCenter,
+        child: ConstrainedBox(
+          constraints: const BoxConstraints(maxWidth: 800),
+          child: ListView(
+            padding: const EdgeInsets.fromLTRB(16, 12, 16, 32),
+            children: [
+              const _SectionHeading(
+                title: '主页排序',
+                subtitle: '长按拖动排序，重启后生效',
+              ),
+              SettingsCard(
+                child: Obx(
+                  () => ReorderableListView(
+                    shrinkWrap: true,
+                    physics: const NeverScrollableScrollPhysics(),
+                    onReorder: controller.updateHomeSort,
+                    children: controller.homeSort.map((key) {
+                      final item = Constant.allHomePages[key]!;
+                      return _ReorderTile(
+                        key: ValueKey(item.title),
+                        title: item.title,
+                        leading: Icon(item.iconData),
+                      );
+                    }).toList(),
+                  ),
+                ),
+              ),
+              const _SectionHeading(
+                title: '平台排序',
+                subtitle: '长按拖动排序，重启后生效',
+                top: 24,
+              ),
+              SettingsCard(
+                child: Obx(
+                  () => ReorderableListView(
+                    shrinkWrap: true,
+                    physics: const NeverScrollableScrollPhysics(),
+                    onReorder: controller.updateSiteSort,
+                    children: controller.siteSort
+                        .where((key) => Sites.allSites[key]?.name != 'Twitch')
+                        .map((key) {
+                      final item = Sites.allSites[key]!;
+                      return _ReorderTile(
+                        key: ValueKey(item.id),
+                        title: item.name,
+                        leading: Image.asset(
+                          item.logo,
+                          width: 24,
+                          height: 24,
+                        ),
+                      );
+                    }).toList(),
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
       ),
-      body: ListView(
-        padding: AppStyle.edgeInsetsA12,
+    );
+  }
+}
+
+class _ReorderTile extends StatelessWidget {
+  const _ReorderTile({
+    required super.key,
+    required this.title,
+    required this.leading,
+  });
+
+  final String title;
+  final Widget leading;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final semantic = context.appTheme;
+    return ListTile(
+      visualDensity: VisualDensity.compact,
+      contentPadding: const EdgeInsets.only(left: 16, right: 12),
+      leading: leading,
+      title: Text(
+        title,
+        maxLines: 1,
+        overflow: TextOverflow.ellipsis,
+        style: theme.textTheme.titleSmall?.copyWith(
+          color: semantic.textPrimary,
+          fontWeight: FontWeight.w600,
+        ),
+      ),
+      trailing: Icon(Icons.drag_handle_rounded, color: semantic.textTertiary),
+    );
+  }
+}
+
+class _SectionHeading extends StatelessWidget {
+  const _SectionHeading({
+    required this.title,
+    required this.subtitle,
+    this.top = 0,
+  });
+
+  final String title;
+  final String subtitle;
+  final double top;
+
+  @override
+  Widget build(BuildContext context) {
+    final semantic = context.appTheme;
+    final theme = Theme.of(context);
+    return Padding(
+      padding: EdgeInsets.fromLTRB(4, top, 4, AppDesignTokens.space8),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          Padding(
-            padding: AppStyle.edgeInsetsA12.copyWith(top: 0),
-            child: Text(
-              "主页排序 (长按拖动排序，重启后生效)",
-              style: Get.textTheme.titleSmall,
+          Text(
+            title,
+            style: theme.textTheme.titleSmall?.copyWith(
+              color: semantic.textSecondary,
+              fontWeight: FontWeight.w700,
             ),
           ),
-          SettingsCard(
-            child: Obx(
-              () => ReorderableListView(
-                shrinkWrap: true,
-                physics: const NeverScrollableScrollPhysics(),
-                onReorder: controller.updateHomeSort,
-                children: controller.homeSort.map(
-                  (key) {
-                    var e = Constant.allHomePages[key]!;
-                    return ListTile(
-                      key: ValueKey(e.title),
-                      title: Text(e.title),
-                      visualDensity: VisualDensity.compact,
-                      leading: Icon(e.iconData),
-                      trailing: const Icon(Icons.drag_handle),
-                    );
-                  },
-                ).toList(),
-              ),
-            ),
-          ),
-          Padding(
-            padding: AppStyle.edgeInsetsA12.copyWith(top: 24),
-            child: Text(
-              "平台排序 (长按拖动排序，重启后生效)",
-              style: Get.textTheme.titleSmall,
-            ),
-          ),
-          SettingsCard(
-            child: Obx(
-              () => ReorderableListView(
-                shrinkWrap: true,
-                physics: const NeverScrollableScrollPhysics(),
-                onReorder: controller.updateSiteSort,
-                children: controller.siteSort
-                    .where((key) => Sites.allSites[key]?.name != 'Twitch')
-                    .map(
-                  (key) {
-                    var e = Sites.allSites[key]!;
-                    return ListTile(
-                      key: ValueKey(e.id),
-                      visualDensity: VisualDensity.compact,
-                      title: Text(e.name),
-                      leading: Image.asset(
-                        e.logo,
-                        width: 24,
-                        height: 24,
-                      ),
-                      trailing: const Icon(Icons.drag_handle),
-                    );
-                  },
-                ).toList(),
-              ),
+          const SizedBox(height: 2),
+          Text(
+            subtitle,
+            style: theme.textTheme.bodySmall?.copyWith(
+              color: semantic.textTertiary,
             ),
           ),
         ],

--- a/simple_live_app/lib/modules/settings/other/other_settings_page.dart
+++ b/simple_live_app/lib/modules/settings/other/other_settings_page.dart
@@ -5,6 +5,7 @@ import 'package:get/get.dart';
 import 'package:remixicon/remixicon.dart';
 import 'package:simple_live_app/app/app_style.dart';
 import 'package:simple_live_app/app/controller/app_settings_controller.dart';
+import 'package:simple_live_app/app/design_system/app_theme_extension.dart';
 import 'package:simple_live_app/app/utils.dart';
 import 'package:simple_live_app/modules/settings/other/other_settings_controller.dart';
 import 'package:simple_live_app/widgets/settings/settings_card.dart';
@@ -21,36 +22,51 @@ class OtherSettingsPage extends GetView<OtherSettingsController> {
       appBar: AppBar(
         title: const Text("其他设置"),
       ),
-      body: ListView(
-        padding: AppStyle.edgeInsetsA12,
-        children: [
+      body: Align(
+        alignment: Alignment.topCenter,
+        child: ConstrainedBox(
+          constraints: const BoxConstraints(maxWidth: 840),
+          child: ListView(
+            padding: const EdgeInsets.fromLTRB(16, 12, 16, 32),
+            children: [
           SettingsCard(
             child: Padding(
               padding: AppStyle.edgeInsetsA4,
-              child: Row(
-                children: [
-                  Expanded(
-                    child: TextButton.icon(
-                      onPressed: controller.exportConfig,
-                      label: const Text("导出配置"),
-                      icon: const Icon(Remix.export_line),
-                    ),
-                  ),
-                  Expanded(
-                    child: TextButton.icon(
-                      onPressed: controller.importConfig,
-                      label: const Text("导入配置"),
-                      icon: const Icon(Remix.import_line),
-                    ),
-                  ),
-                  Expanded(
-                    child: TextButton.icon(
-                      onPressed: controller.resetDefaultConfig,
-                      label: const Text("重置配置"),
-                      icon: const Icon(Remix.restart_line),
-                    ),
-                  ),
-                ],
+              child: LayoutBuilder(
+                builder: (context, constraints) {
+                  final stacked = constraints.maxWidth < 420;
+                  final buttonWidth = stacked
+                      ? constraints.maxWidth
+                      : constraints.maxWidth / 3;
+                  return Wrap(
+                    children: [
+                      SizedBox(
+                        width: buttonWidth,
+                        child: TextButton.icon(
+                          onPressed: controller.exportConfig,
+                          label: const Text("导出配置"),
+                          icon: const Icon(Remix.export_line),
+                        ),
+                      ),
+                      SizedBox(
+                        width: buttonWidth,
+                        child: TextButton.icon(
+                          onPressed: controller.importConfig,
+                          label: const Text("导入配置"),
+                          icon: const Icon(Remix.import_line),
+                        ),
+                      ),
+                      SizedBox(
+                        width: buttonWidth,
+                        child: TextButton.icon(
+                          onPressed: controller.resetDefaultConfig,
+                          label: const Text("重置配置"),
+                          icon: const Icon(Remix.restart_line),
+                        ),
+                      ),
+                    ],
+                  );
+                },
               ),
             ),
           ),
@@ -65,27 +81,29 @@ class OtherSettingsPage extends GetView<OtherSettingsController> {
             padding: AppStyle.edgeInsetsA12.copyWith(top: 0),
             child: Text.rich(
               TextSpan(
-                text: "请勿随意修改以下设置，除非你知道自己在做什么。\n在修改以下设置前，你应该先查阅",
+                text: "请勿随意修改以下设置，除非你知道自己在做什么。\n在修改以下设置前，你应该先查阅 ",
                 children: [
                   WidgetSpan(
                     child: GestureDetector(
                       onTap: () {
                         launchUrlString(
-                            "https://mpv.io/manual/stable/#video-output-drivers");
+                          "https://mpv.io/manual/stable/#video-output-drivers",
+                        );
                       },
-                      child: const Text(
+                      child: Text(
                         "MPV的文档",
-                        style: TextStyle(
-                          color: Colors.blue,
-                          fontSize: 12,
-                          decoration: TextDecoration.underline,
-                        ),
+                        style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                              color: Theme.of(context).colorScheme.primary,
+                              decoration: TextDecoration.underline,
+                            ),
                       ),
                     ),
                   ),
                 ],
               ),
-              style: const TextStyle(fontSize: 12, color: Colors.grey),
+              style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                    color: context.appTheme.textSecondary,
+                  ),
             ),
           ),
           SettingsCard(
@@ -235,7 +253,9 @@ class OtherSettingsPage extends GetView<OtherSettingsController> {
               ),
             ),
           ),
-        ],
+            ],
+          ),
+        ),
       ),
     );
   }

--- a/simple_live_app/lib/modules/settings/play_settings_page.dart
+++ b/simple_live_app/lib/modules/settings/play_settings_page.dart
@@ -18,9 +18,13 @@ class PlaySettingsPage extends GetView<AppSettingsController> {
       appBar: AppBar(
         title: const Text("直播间设置"),
       ),
-      body: ListView(
-        padding: AppStyle.edgeInsetsA12,
-        children: [
+      body: Align(
+        alignment: Alignment.topCenter,
+        child: ConstrainedBox(
+          constraints: const BoxConstraints(maxWidth: 800),
+          child: ListView(
+            padding: const EdgeInsets.fromLTRB(16, 12, 16, 32),
+            children: [
           Padding(
             padding: AppStyle.edgeInsetsA12.copyWith(top: 0),
             child: Text(
@@ -247,7 +251,9 @@ class PlaySettingsPage extends GetView<AppSettingsController> {
               ],
             ),
           ),
-        ],
+            ],
+          ),
+        ),
       ),
     );
   }

--- a/simple_live_app/lib/modules/sync/local_sync/device/sync_device_page.dart
+++ b/simple_live_app/lib/modules/sync/local_sync/device/sync_device_page.dart
@@ -2,7 +2,10 @@ import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import 'package:remixicon/remixicon.dart';
 import 'package:simple_live_app/app/app_style.dart';
+import 'package:simple_live_app/app/design_system/app_design_tokens.dart';
+import 'package:simple_live_app/app/design_system/app_theme_extension.dart';
 import 'package:simple_live_app/modules/sync/local_sync/device/sync_device_controller.dart';
+import 'package:simple_live_app/widgets/settings/settings_action.dart';
 import 'package:simple_live_app/widgets/settings/settings_card.dart';
 
 class SyncDevicePage extends GetView<SyncDeviceController> {
@@ -10,85 +13,137 @@ class SyncDevicePage extends GetView<SyncDeviceController> {
 
   @override
   Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final semantic = context.appTheme;
+
     return Scaffold(
-      appBar: AppBar(
-        title: const Text("同步"),
-      ),
-      body: ListView(
-        padding: AppStyle.edgeInsetsA12.copyWith(top: 0),
-        children: [
-          SettingsCard(
-            child: ListTile(
-              leading: buildIcon(),
-              title: Text(controller.info.name),
-              subtitle: Text(
-                  "${controller.info.type.toUpperCase()}   ${controller.info.address}"),
-            ),
+      appBar: AppBar(title: const Text('同步')),
+      body: Align(
+        alignment: Alignment.topCenter,
+        child: ConstrainedBox(
+          constraints: const BoxConstraints(maxWidth: 800),
+          child: ListView(
+            padding: const EdgeInsets.fromLTRB(16, 12, 16, 32),
+            children: [
+              SettingsCard(
+                child: Padding(
+                  padding: const EdgeInsets.all(AppDesignTokens.space16),
+                  child: Row(
+                    children: [
+                      Container(
+                        width: 52,
+                        height: 52,
+                        decoration: BoxDecoration(
+                          color: theme.colorScheme.primary.withAlpha(18),
+                          borderRadius: BorderRadius.circular(
+                            AppDesignTokens.radius12,
+                          ),
+                        ),
+                        child: IconTheme(
+                          data: IconThemeData(
+                            color: theme.colorScheme.primary,
+                            size: 26,
+                          ),
+                          child: buildIcon(),
+                        ),
+                      ),
+                      const SizedBox(width: AppDesignTokens.space12),
+                      Expanded(
+                        child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            Text(
+                              controller.info.name,
+                              maxLines: 1,
+                              overflow: TextOverflow.ellipsis,
+                              style: theme.textTheme.titleMedium?.copyWith(
+                                color: semantic.textPrimary,
+                                fontWeight: FontWeight.w700,
+                              ),
+                            ),
+                            const SizedBox(height: AppDesignTokens.space4),
+                            Text(
+                              '${controller.info.type.toUpperCase()} · ${controller.info.address}',
+                              maxLines: 2,
+                              overflow: TextOverflow.ellipsis,
+                              style: theme.textTheme.bodySmall?.copyWith(
+                                color: semantic.textSecondary,
+                              ),
+                            ),
+                          ],
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+              const _SectionHeading(title: '发送到此设备', top: 24),
+              SettingsCard(
+                child: Column(
+                  children: [
+                    SettingsAction(
+                      leading: const Icon(Remix.heart_line),
+                      title: '同步关注列表',
+                      onTap: controller.syncFollowAndTag,
+                    ),
+                    AppStyle.divider,
+                    SettingsAction(
+                      leading: const Icon(Icons.history_rounded),
+                      title: '同步观看记录',
+                      onTap: controller.syncHistory,
+                    ),
+                    AppStyle.divider,
+                    SettingsAction(
+                      leading: const Icon(Remix.shield_keyhole_line),
+                      title: '同步弹幕屏蔽词',
+                      onTap: controller.syncBlockedWord,
+                    ),
+                    AppStyle.divider,
+                    SettingsAction(
+                      leading: const Icon(Remix.account_circle_line),
+                      title: '同步哔哩哔哩账号',
+                      onTap: controller.syncBiliAccount,
+                    ),
+                  ],
+                ),
+              ),
+            ],
           ),
-          AppStyle.vGap12,
-          SettingsCard(
-            child: Column(
-              children: [
-                ListTile(
-                  leading: const Icon(Remix.heart_line),
-                  title: const Text("同步关注列表"),
-                  trailing: const Icon(Icons.chevron_right),
-                  onTap: () {
-                    controller.syncFollowAndTag();
-                  },
-                ),
-                AppStyle.divider,
-                ListTile(
-                  leading: const Icon(Icons.history),
-                  title: const Text("同步观看记录"),
-                  trailing: const Icon(Icons.chevron_right),
-                  onTap: () {
-                    controller.syncHistory();
-                  },
-                ),
-                AppStyle.divider,
-                ListTile(
-                  leading: const Icon(Remix.shield_keyhole_line),
-                  title: const Text("同步弹幕屏蔽词"),
-                  trailing: const Icon(Icons.chevron_right),
-                  onTap: () {
-                    controller.syncBlockedWord();
-                  },
-                ),
-                AppStyle.divider,
-                ListTile(
-                  leading: const Icon(Remix.account_circle_line),
-                  title: const Text("同步哔哩哔哩账号"),
-                  trailing: const Icon(Icons.chevron_right),
-                  onTap: () {
-                    controller.syncBiliAccount();
-                  },
-                ),
-              ],
-            ),
-          ),
-        ],
+        ),
       ),
     );
   }
 
   Widget buildIcon() {
-    var icon = controller.info.type.toLowerCase();
+    final icon = controller.info.type.toLowerCase();
+    if (icon == 'android') return const Icon(Remix.android_line);
+    if (icon == 'ios') return const Icon(Remix.apple_line);
+    if (icon == 'tv') return const Icon(Remix.tv_2_line);
+    if (icon == 'windows') return const Icon(Remix.microsoft_fill);
+    if (icon == 'macos') return const Icon(Remix.mac_line);
+    if (icon == 'linux') return const Icon(Remix.ubuntu_line);
+    return const Icon(Remix.device_line);
+  }
+}
 
-    if (icon == "android") {
-      return const Icon(Remix.android_line);
-    } else if (icon == "ios") {
-      return const Icon(Remix.apple_line);
-    } else if (icon == "tv") {
-      return const Icon(Remix.tv_2_line);
-    } else if (icon == "windows") {
-      return const Icon(Remix.microsoft_fill);
-    } else if (icon == "macos") {
-      return const Icon(Remix.mac_line);
-    } else if (icon == "linux") {
-      return const Icon(Remix.ubuntu_line);
-    } else {
-      return const Icon(Remix.device_line);
-    }
+class _SectionHeading extends StatelessWidget {
+  const _SectionHeading({required this.title, this.top = 0});
+
+  final String title;
+  final double top;
+
+  @override
+  Widget build(BuildContext context) {
+    final semantic = context.appTheme;
+    return Padding(
+      padding: EdgeInsets.fromLTRB(4, top, 4, AppDesignTokens.space8),
+      child: Text(
+        title,
+        style: Theme.of(context).textTheme.titleSmall?.copyWith(
+          color: semantic.textSecondary,
+          fontWeight: FontWeight.w700,
+        ),
+      ),
+    );
   }
 }

--- a/simple_live_app/lib/modules/sync/local_sync/local_sync_page.dart
+++ b/simple_live_app/lib/modules/sync/local_sync/local_sync_page.dart
@@ -4,6 +4,8 @@ import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import 'package:remixicon/remixicon.dart';
 import 'package:simple_live_app/app/app_style.dart';
+import 'package:simple_live_app/app/design_system/app_design_tokens.dart';
+import 'package:simple_live_app/app/design_system/app_theme_extension.dart';
 import 'package:simple_live_app/modules/sync/local_sync/local_sync_controller.dart';
 import 'package:simple_live_app/services/sync_service.dart';
 import 'package:simple_live_app/widgets/settings/settings_card.dart';
@@ -13,108 +15,187 @@ class LocalSyncPage extends GetView<LocalSyncController> {
 
   @override
   Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final semantic = context.appTheme;
+
     return Scaffold(
       appBar: AppBar(
         title: const Text('局域网数据同步'),
         actions: [
           TextButton.icon(
             onPressed: controller.showInfo,
-            icon: const Icon(Icons.qr_code),
-            label: const Text("信息"),
+            icon: const Icon(Icons.qr_code_rounded),
+            label: const Text('本机信息'),
           ),
+          const SizedBox(width: AppDesignTokens.space8),
         ],
       ),
-      body: ListView(
-        padding: AppStyle.edgeInsetsA12,
-        children: [
-          SettingsCard(
-            child: Padding(
-              padding: AppStyle.edgeInsetsA12,
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.stretch,
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  TextField(
-                    controller: controller.addressController,
-                    onSubmitted: (e) {
-                      controller.connect();
-                    },
-                    decoration: InputDecoration(
-                      labelText: '客户端地址',
-                      hintText: '请输入地址或扫码自动填写',
-                      contentPadding: AppStyle.edgeInsetsH12,
-                      border: const OutlineInputBorder(),
-                      suffixIcon: Visibility(
-                        visible: Platform.isAndroid || Platform.isIOS,
-                        child: TextButton.icon(
-                          onPressed: controller.toScanQr,
-                          icon: const Icon(Remix.qr_scan_line),
-                          label: const Text("扫一扫"),
+      body: Align(
+        alignment: Alignment.topCenter,
+        child: ConstrainedBox(
+          constraints: const BoxConstraints(maxWidth: 800),
+          child: ListView(
+            padding: const EdgeInsets.fromLTRB(16, 12, 16, 32),
+            children: [
+              const _SectionHeading(title: '手动连接'),
+              SettingsCard(
+                child: Padding(
+                  padding: const EdgeInsets.all(AppDesignTokens.space16),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.stretch,
+                    children: [
+                      TextField(
+                        controller: controller.addressController,
+                        onSubmitted: (_) => controller.connect(),
+                        decoration: InputDecoration(
+                          labelText: '客户端地址',
+                          hintText: '请输入地址或扫码自动填写',
+                          border: const OutlineInputBorder(),
+                          prefixIcon: const Icon(Icons.lan_outlined),
+                          suffixIcon: Visibility(
+                            visible: Platform.isAndroid || Platform.isIOS,
+                            child: IconButton(
+                              onPressed: controller.toScanQr,
+                              tooltip: '扫一扫',
+                              icon: const Icon(Remix.qr_scan_line),
+                            ),
+                          ),
                         ),
                       ),
-                    ),
+                      const SizedBox(height: AppDesignTokens.space12),
+                      FilledButton.icon(
+                        onPressed: controller.connect,
+                        icon: const Icon(Icons.link_rounded),
+                        label: const Text('连接'),
+                      ),
+                    ],
                   ),
-                  AppStyle.vGap12,
-                  ElevatedButton(
-                    onPressed: () {
-                      controller.connect();
-                    },
-                    child: const Text("连接"),
+                ),
+              ),
+              Obx(
+                () => _SectionHeading(
+                  title: '已发现设备 (${SyncService.instance.scanClients.length})',
+                  top: 24,
+                  trailing: IconButton(
+                    onPressed: SyncService.instance.refreshClients,
+                    tooltip: '重新扫描',
+                    icon: const Icon(Icons.refresh_rounded),
                   ),
-                ],
+                ),
+              ),
+              SettingsCard(
+                child: Obx(
+                  () => SyncService.instance.scanClients.isEmpty
+                      ? Padding(
+                          padding: const EdgeInsets.symmetric(vertical: 32),
+                          child: Column(
+                            children: [
+                              Icon(
+                                Icons.devices_other_outlined,
+                                color: semantic.textTertiary,
+                              ),
+                              const SizedBox(height: AppDesignTokens.space8),
+                              Text(
+                                '暂未发现设备',
+                                style: theme.textTheme.bodyMedium?.copyWith(
+                                  color: semantic.textSecondary,
+                                ),
+                              ),
+                            ],
+                          ),
+                        )
+                      : ListView.separated(
+                          shrinkWrap: true,
+                          padding: EdgeInsets.zero,
+                          physics: const NeverScrollableScrollPhysics(),
+                          separatorBuilder: (_, __) => AppStyle.divider,
+                          itemCount: SyncService.instance.scanClients.length,
+                          itemBuilder: (_, index) {
+                            final client =
+                                SyncService.instance.scanClients[index];
+                            return ListTile(
+                              visualDensity: VisualDensity.compact,
+                              contentPadding: const EdgeInsets.only(
+                                left: 16,
+                                right: 12,
+                              ),
+                              leading: Icon(
+                                Icons.devices_rounded,
+                                color: semantic.textSecondary,
+                              ),
+                              title: Text(
+                                client.name,
+                                maxLines: 1,
+                                overflow: TextOverflow.ellipsis,
+                                style: theme.textTheme.titleSmall?.copyWith(
+                                  color: semantic.textPrimary,
+                                  fontWeight: FontWeight.w600,
+                                ),
+                              ),
+                              subtitle: Text(
+                                client.address,
+                                maxLines: 1,
+                                overflow: TextOverflow.ellipsis,
+                                style: theme.textTheme.bodySmall?.copyWith(
+                                  color: semantic.textSecondary,
+                                ),
+                              ),
+                              trailing: Icon(
+                                Icons.chevron_right_rounded,
+                                color: semantic.textTertiary,
+                              ),
+                              onTap: () => controller.connectClient(client),
+                            );
+                          },
+                        ),
+                ),
+              ),
+              const SizedBox(height: AppDesignTokens.space12),
+              Text(
+                '如果无法扫描到设备，请手动输入地址。',
+                textAlign: TextAlign.center,
+                style: theme.textTheme.bodySmall?.copyWith(
+                  color: semantic.textTertiary,
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _SectionHeading extends StatelessWidget {
+  const _SectionHeading({
+    required this.title,
+    this.top = 0,
+    this.trailing,
+  });
+
+  final String title;
+  final double top;
+  final Widget? trailing;
+
+  @override
+  Widget build(BuildContext context) {
+    final semantic = context.appTheme;
+    return Padding(
+      padding: EdgeInsets.fromLTRB(4, top, 4, AppDesignTokens.space8),
+      child: Row(
+        children: [
+          Expanded(
+            child: Text(
+              title,
+              maxLines: 2,
+              overflow: TextOverflow.ellipsis,
+              style: Theme.of(context).textTheme.titleSmall?.copyWith(
+                color: semantic.textSecondary,
+                fontWeight: FontWeight.w700,
               ),
             ),
           ),
-          AppStyle.vGap12,
-          ListTile(
-            title: Obx(
-              () => Text(
-                "已发现设备(${SyncService.instance.scanClients.length})",
-                style: Get.textTheme.titleSmall,
-              ),
-            ),
-            visualDensity: VisualDensity.compact,
-            contentPadding: AppStyle.edgeInsetsH12,
-            trailing: IconButton(
-              visualDensity: VisualDensity.compact,
-              onPressed: () {
-                SyncService.instance.refreshClients();
-              },
-              icon: const Icon(Icons.refresh),
-            ),
-          ),
-          SettingsCard(
-            child: Obx(
-              () => ListView.separated(
-                shrinkWrap: true,
-                padding: EdgeInsets.zero,
-                physics: const NeverScrollableScrollPhysics(),
-                separatorBuilder: (BuildContext context, int index) =>
-                    AppStyle.divider,
-                itemCount: SyncService.instance.scanClients.length,
-                itemBuilder: (BuildContext context, int index) {
-                  var client = SyncService.instance.scanClients[index];
-                  return ListTile(
-                    title: Text(client.name),
-                    subtitle: Text(client.address),
-                    trailing: const Icon(Icons.chevron_right),
-                    onTap: () {
-                      controller.connectClient(client);
-                    },
-                  );
-                },
-              ),
-            ),
-          ),
-          AppStyle.vGap12,
-          const Text(
-            "如果无法扫描到设备，请手动输入地址",
-            textAlign: TextAlign.center,
-            style: TextStyle(
-              color: Colors.grey,
-              fontSize: 14,
-            ),
-          ),
+          if (trailing != null) trailing!,
         ],
       ),
     );

--- a/simple_live_app/lib/modules/sync/remote_sync/room/remote_sync_room_page.dart
+++ b/simple_live_app/lib/modules/sync/remote_sync/room/remote_sync_room_page.dart
@@ -2,6 +2,8 @@ import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import 'package:remixicon/remixicon.dart';
 import 'package:simple_live_app/app/app_style.dart';
+import 'package:simple_live_app/app/design_system/app_design_tokens.dart';
+import 'package:simple_live_app/app/design_system/app_theme_extension.dart';
 import 'package:simple_live_app/app/utils.dart';
 import 'package:simple_live_app/modules/sync/remote_sync/room/remote_sync_room_controller.dart';
 import 'package:simple_live_app/services/signalr_service.dart';
@@ -17,81 +19,43 @@ class RemoteSyncRoomPage extends GetView<RemoteSyncRoomController> {
         title: const Text("数据同步"),
         actions: [
           Padding(
-            padding: AppStyle.edgeInsetsH12,
+            padding: const EdgeInsets.symmetric(horizontal: 12),
             child: StreamBuilder<SignalRConnectionState>(
               stream: controller.signalR.stateStream,
               builder: (context, snapshot) {
-                if (snapshot.hasData) {
-                  switch (snapshot.data) {
-                    case SignalRConnectionState.connected:
-                      return Row(
-                        children: [
-                          Container(
-                            width: 8,
-                            height: 8,
-                            decoration: const BoxDecoration(
-                              color: Colors.green,
-                              shape: BoxShape.circle,
-                            ),
-                          ),
-                          AppStyle.hGap8,
-                          const Text(
-                            '已连接',
-                            style: TextStyle(
-                              fontSize: 14,
-                            ),
-                          ),
-                        ],
-                      );
-                    case SignalRConnectionState.disconnected:
-                      return Row(
-                        children: [
-                          Container(
-                            width: 8,
-                            height: 8,
-                            decoration: const BoxDecoration(
-                              color: Colors.red,
-                              shape: BoxShape.circle,
-                            ),
-                          ),
-                          AppStyle.hGap8,
-                          const Text(
-                            '断开连接',
-                            style: TextStyle(
-                              fontSize: 14,
-                            ),
-                          ),
-                        ],
-                      );
-                    default:
-                      return const Row(
-                        children: [
-                          SizedBox(
-                            width: 16,
-                            height: 16,
-                            child: CircularProgressIndicator(
-                              strokeWidth: 2,
-                            ),
-                          ),
-                          Text(
-                            '连接中',
-                            style: TextStyle(
-                              fontSize: 14,
-                            ),
-                          ),
-                        ],
-                      );
-                  }
+                if (!snapshot.hasData) return const SizedBox();
+                switch (snapshot.data) {
+                  case SignalRConnectionState.connected:
+                    return const _ConnectionStatus(
+                      icon: Icons.check_circle_outline_rounded,
+                      label: '已连接',
+                      state: _ConnectionVisualState.connected,
+                    );
+                  case SignalRConnectionState.disconnected:
+                    return const _ConnectionStatus(
+                      icon: Icons.error_outline_rounded,
+                      label: '断开连接',
+                      state: _ConnectionVisualState.disconnected,
+                    );
+                  default:
+                    return const _ConnectionStatus(
+                      icon: Icons.sync_rounded,
+                      label: '连接中',
+                      state: _ConnectionVisualState.connecting,
+                    );
                 }
-                return const SizedBox();
               },
             ),
           ),
         ],
       ),
-      body: ListView(
-        padding: AppStyle.edgeInsetsA12.copyWith(top: 0),
-        children: [
+      body: Align(
+        alignment: Alignment.topCenter,
+        child: ConstrainedBox(
+          constraints: const BoxConstraints(maxWidth: 840),
+          child: ListView(
+            padding: const EdgeInsets.fromLTRB(16, 12, 16, 32),
+            children: [
           Visibility(
             visible: controller.roomId.isEmpty,
             child: SettingsCard(
@@ -215,7 +179,9 @@ class RemoteSyncRoomPage extends GetView<RemoteSyncRoomController> {
                 separatorBuilder: (context, index) => AppStyle.divider,
                 physics: const NeverScrollableScrollPhysics(),
                 itemBuilder: (BuildContext context, int index) {
-                  var user = controller.roomUsers[index];
+                  final user = controller.roomUsers[index];
+                  final semantic = context.appTheme;
+                  final theme = Theme.of(context);
                   return ListTile(
                     visualDensity: VisualDensity.compact,
                     leading: SizedBox(
@@ -228,22 +194,34 @@ class RemoteSyncRoomPage extends GetView<RemoteSyncRoomController> {
                     title: Text.rich(
                       TextSpan(
                         text: user.shortId,
-                        style: const TextStyle(fontSize: 16),
+                        style: theme.textTheme.titleSmall?.copyWith(
+                          color: semantic.textPrimary,
+                          fontWeight: FontWeight.w600,
+                        ),
                         children: user.isCreator!
                             ? [
                                 WidgetSpan(
+                                  alignment: PlaceholderAlignment.middle,
                                   child: Container(
                                     margin: AppStyle.edgeInsetsL4,
-                                    padding: AppStyle.edgeInsetsH4,
-                                    decoration: BoxDecoration(
-                                      border: Border.all(color: Colors.blue),
-                                      borderRadius: BorderRadius.circular(4),
+                                    padding: const EdgeInsets.symmetric(
+                                      horizontal: 6,
+                                      vertical: 2,
                                     ),
-                                    child: const Text(
+                                    decoration: BoxDecoration(
+                                      color: theme.colorScheme.primary.withAlpha(18),
+                                      border: Border.all(
+                                        color: theme.colorScheme.primary.withAlpha(54),
+                                      ),
+                                      borderRadius: BorderRadius.circular(
+                                        AppDesignTokens.radius6,
+                                      ),
+                                    ),
+                                    child: Text(
                                       "创建者",
-                                      style: TextStyle(
-                                        color: Colors.blue,
-                                        fontSize: 12,
+                                      style: theme.textTheme.labelSmall?.copyWith(
+                                        color: theme.colorScheme.primary,
+                                        fontWeight: FontWeight.w600,
                                       ),
                                     ),
                                   ),
@@ -252,7 +230,14 @@ class RemoteSyncRoomPage extends GetView<RemoteSyncRoomController> {
                             : null,
                       ),
                     ),
-                    subtitle: Text("${user.app} - v${user.version}"),
+                    subtitle: Text(
+                      "${user.app} - v${user.version}",
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                      style: theme.textTheme.bodySmall?.copyWith(
+                        color: semantic.textSecondary,
+                      ),
+                    ),
                     trailing: Visibility(
                       visible: controller.signalR.hubConnection?.connectionId ==
                           user.connectionId,
@@ -265,7 +250,9 @@ class RemoteSyncRoomPage extends GetView<RemoteSyncRoomController> {
               ),
             ),
           )
-        ],
+            ],
+          ),
+        ),
       ),
     );
   }
@@ -288,5 +275,52 @@ class RemoteSyncRoomPage extends GetView<RemoteSyncRoomController> {
     } else {
       return const Icon(Remix.device_line);
     }
+  }
+}
+
+enum _ConnectionVisualState { connected, disconnected, connecting }
+
+class _ConnectionStatus extends StatelessWidget {
+  const _ConnectionStatus({
+    required this.icon,
+    required this.label,
+    required this.state,
+  });
+
+  final IconData icon;
+  final String label;
+  final _ConnectionVisualState state;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final semantic = context.appTheme;
+    final color = switch (state) {
+      _ConnectionVisualState.connected => theme.colorScheme.primary,
+      _ConnectionVisualState.disconnected => theme.colorScheme.error,
+      _ConnectionVisualState.connecting => semantic.textSecondary,
+    };
+
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        if (state == _ConnectionVisualState.connecting)
+          SizedBox(
+            width: 16,
+            height: 16,
+            child: CircularProgressIndicator(strokeWidth: 2, color: color),
+          )
+        else
+          Icon(icon, size: 18, color: color),
+        const SizedBox(width: AppDesignTokens.space4),
+        Text(
+          label,
+          style: theme.textTheme.labelMedium?.copyWith(
+            color: color,
+            fontWeight: FontWeight.w600,
+          ),
+        ),
+      ],
+    );
   }
 }

--- a/simple_live_app/lib/modules/sync/remote_sync/webdav/remote_sync_webdav_config_page.dart
+++ b/simple_live_app/lib/modules/sync/remote_sync/webdav/remote_sync_webdav_config_page.dart
@@ -2,10 +2,12 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_smart_dialog/flutter_smart_dialog.dart';
 import 'package:get/get.dart';
-import 'package:simple_live_app/app/app_style.dart';
+import 'package:simple_live_app/app/design_system/app_design_tokens.dart';
+import 'package:simple_live_app/app/design_system/app_theme_extension.dart';
 import 'package:simple_live_app/app/utils.dart';
 import 'package:simple_live_app/modules/sync/remote_sync/webdav/remote_sync_webdav_controller.dart';
 import 'package:simple_live_app/widgets/none_border_circular_textfield.dart';
+import 'package:simple_live_app/widgets/settings/settings_card.dart';
 
 class RemoteSyncWebDAVConfigPage extends StatefulWidget {
   const RemoteSyncWebDAVConfigPage({super.key});
@@ -39,121 +41,152 @@ class _RemoteSyncWebDAVConfigPageState
 
   @override
   Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final semantic = context.appTheme;
+
     return Scaffold(
       appBar: AppBar(
-        title: const Text("WebDAV账号配置"),
-        centerTitle: true,
+        title: const Text('WebDAV账号配置'),
         actions: [
           IconButton(
-            icon: const Icon(Icons.help_outline),
+            icon: const Icon(Icons.help_outline_rounded),
+            tooltip: '配置帮助',
             onPressed: () {
               Utils.showInformationHelpDialog(
                 content: [
-                  const Text("此功能可以将您的数据备份到 WebDAV 服务器中或者进行数据恢复.\n"),
+                  const Text('此功能可以将您的数据备份到 WebDAV 服务器中或者进行数据恢复。\n'),
                   const Text(
-                      "WebDAV 服务器地址请以 http:// 或 https:// 开头，如坚果云(点击复制)："),
+                    'WebDAV 服务器地址请以 http:// 或 https:// 开头，如坚果云（点击复制）：',
+                  ),
                   Padding(
                     padding: const EdgeInsets.symmetric(vertical: 16),
                     child: InkWell(
                       onTap: () {
-                        Clipboard.setData(const ClipboardData(
-                            text: "https://dav.jianguoyun.com/dav/"));
-                        SmartDialog.showToast("复制成功");
+                        Clipboard.setData(
+                          const ClipboardData(
+                            text: 'https://dav.jianguoyun.com/dav/',
+                          ),
+                        );
+                        SmartDialog.showToast('复制成功');
                       },
-                      child: const Text("https://dav.jianguoyun.com/dav/"),
+                      child: Text(
+                        'https://dav.jianguoyun.com/dav/',
+                        style: theme.textTheme.bodyMedium?.copyWith(
+                          color: theme.colorScheme.primary,
+                          decoration: TextDecoration.underline,
+                        ),
+                      ),
                     ),
                   ),
                 ],
               );
             },
           ),
+          const SizedBox(width: AppDesignTokens.space8),
         ],
       ),
       body: GetX<RemoteSyncWebDAVController>(
         builder: (controller) {
-          return SingleChildScrollView(
-            child: Padding(
-              padding: AppStyle.edgeInsetsA12.copyWith(top: 0),
-              child: Column(
-                mainAxisAlignment: MainAxisAlignment.center,
-                children: [
-                  NoneBorderCircularTextField(
-                    editingController: _urlController,
-                    labelText: "WebDAV服务器地址",
-                    hintText: "请以http:// 或 http:// 开头",
-                    prefixIcon: const Icon(Icons.public),
-                    trailing: InkWell(
-                      child: const Icon(
-                        Icons.cancel,
-                        size: 20,
-                      ),
-                      onTap: () => _urlController.clear(),
-                    ),
-                  ),
-                  NoneBorderCircularTextField(
-                    editingController: _userNameController,
-                    labelText: "账号",
-                    prefixIcon: const Icon(Icons.account_circle),
-                    trailing: InkWell(
-                        child: const Icon(
-                          Icons.cancel,
-                          size: 20,
+          return Align(
+            alignment: Alignment.topCenter,
+            child: ConstrainedBox(
+              constraints: const BoxConstraints(maxWidth: 720),
+              child: SingleChildScrollView(
+                padding: const EdgeInsets.fromLTRB(16, 12, 16, 32),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.stretch,
+                  children: [
+                    Container(
+                      padding: const EdgeInsets.all(AppDesignTokens.space16),
+                      decoration: BoxDecoration(
+                        color: theme.colorScheme.primary.withAlpha(14),
+                        borderRadius: BorderRadius.circular(
+                          AppDesignTokens.radius12,
                         ),
-                        onTap: () => _userNameController.clear()),
-                  ),
-                  NoneBorderCircularTextField(
-                    editingController: _passwordController,
-                    labelText: "密码",
-                    prefixIcon: const Icon(Icons.lock),
-                    obscureText: controller.passwordVisible.value,
-                    trailing: Row(
-                      mainAxisSize: MainAxisSize.min,
-                      children: [
-                        InkWell(
-                          child: const Icon(
-                            Icons.cancel,
-                            size: 20,
-                          ),
-                          onTap: () => _passwordController.clear(),
+                        border: Border.all(
+                          color: theme.colorScheme.primary.withAlpha(36),
                         ),
-                        AppStyle.hGap12,
-                        InkWell(
-                          child: controller.passwordVisible.value
-                              ? const Icon(Icons.visibility_off)
-                              : const Icon(Icons.visibility),
-                          onTap: () {
-                            controller.changePasswordVisible();
-                          },
+                      ),
+                      child: Text(
+                        '填写您的 WebDAV 服务地址与账号信息。凭据将保存在本机。',
+                        style: theme.textTheme.bodyMedium?.copyWith(
+                          color: semantic.textSecondary,
                         ),
-                      ],
-                    ),
-                  ),
-                  Padding(
-                    padding: const EdgeInsets.only(top: 5, bottom: 15),
-                    child: MaterialButton(
-                      minWidth: double.infinity,
-                      color: Theme.of(context).primaryColor,
-                      focusElevation: 0,
-                      elevation: 0,
-                      highlightElevation: 4,
-                      height: 40,
-                      shape: const RoundedRectangleBorder(
-                        borderRadius: BorderRadius.all(Radius.circular(8.0)),
                       ),
-                      child: const Text(
-                        "登录",
-                        style: TextStyle(color: Colors.white),
-                      ),
-                      onPressed: () {
-                        controller.doWebDAVLogin(
-                          _urlController.text,
-                          _userNameController.text,
-                          _passwordController.text,
-                        );
-                      },
                     ),
-                  )
-                ],
+                    const SizedBox(height: AppDesignTokens.space16),
+                    SettingsCard(
+                      child: Padding(
+                        padding: const EdgeInsets.all(AppDesignTokens.space16),
+                        child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.stretch,
+                          children: [
+                            NoneBorderCircularTextField(
+                              editingController: _urlController,
+                              labelText: 'WebDAV服务器地址',
+                              hintText: '请以 http:// 或 https:// 开头',
+                              prefixIcon: const Icon(Icons.public_rounded),
+                              trailing: IconButton(
+                                tooltip: '清空地址',
+                                onPressed: _urlController.clear,
+                                icon: const Icon(Icons.cancel, size: 20),
+                              ),
+                            ),
+                            NoneBorderCircularTextField(
+                              editingController: _userNameController,
+                              labelText: '账号',
+                              prefixIcon: const Icon(Icons.account_circle),
+                              trailing: IconButton(
+                                tooltip: '清空账号',
+                                onPressed: _userNameController.clear,
+                                icon: const Icon(Icons.cancel, size: 20),
+                              ),
+                            ),
+                            NoneBorderCircularTextField(
+                              editingController: _passwordController,
+                              labelText: '密码',
+                              prefixIcon: const Icon(Icons.lock_outline_rounded),
+                              obscureText: controller.passwordVisible.value,
+                              trailing: Row(
+                                mainAxisSize: MainAxisSize.min,
+                                children: [
+                                  IconButton(
+                                    tooltip: '清空密码',
+                                    onPressed: _passwordController.clear,
+                                    icon: const Icon(Icons.cancel, size: 20),
+                                  ),
+                                  IconButton(
+                                    tooltip: controller.passwordVisible.value
+                                        ? '显示密码'
+                                        : '隐藏密码',
+                                    onPressed: controller.changePasswordVisible,
+                                    icon: Icon(
+                                      controller.passwordVisible.value
+                                          ? Icons.visibility_off
+                                          : Icons.visibility,
+                                    ),
+                                  ),
+                                ],
+                              ),
+                            ),
+                            const SizedBox(height: AppDesignTokens.space12),
+                            FilledButton.icon(
+                              onPressed: () {
+                                controller.doWebDAVLogin(
+                                  _urlController.text,
+                                  _userNameController.text,
+                                  _passwordController.text,
+                                );
+                              },
+                              icon: const Icon(Icons.login_rounded),
+                              label: const Text('登录'),
+                            ),
+                          ],
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
               ),
             ),
           );

--- a/simple_live_app/lib/modules/sync/remote_sync/webdav/remote_sync_webdav_page.dart
+++ b/simple_live_app/lib/modules/sync/remote_sync/webdav/remote_sync_webdav_page.dart
@@ -2,9 +2,12 @@ import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import 'package:remixicon/remixicon.dart';
 import 'package:simple_live_app/app/app_style.dart';
+import 'package:simple_live_app/app/design_system/app_design_tokens.dart';
+import 'package:simple_live_app/app/design_system/app_theme_extension.dart';
 import 'package:simple_live_app/app/utils.dart';
 import 'package:simple_live_app/modules/sync/remote_sync/webdav/remote_sync_webdav_controller.dart';
 import 'package:simple_live_app/routes/route_path.dart';
+import 'package:simple_live_app/widgets/settings/settings_action.dart';
 import 'package:simple_live_app/widgets/settings/settings_card.dart';
 
 class RemoteSyncWebDAVPage extends GetView<RemoteSyncWebDAVController> {
@@ -13,94 +16,81 @@ class RemoteSyncWebDAVPage extends GetView<RemoteSyncWebDAVController> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(
-        title: const Text("WebDAV同步"),
-      ),
-      body: ListView(
-        padding: AppStyle.edgeInsetsA12,
-        children: [
-          SettingsCard(
-            child: Obx(
-              () => Column(
-                children: controller.notLogin.value
-                    ? [
-                        ListTile(
-                          title: const Text("点击登录"),
-                          leading: const Icon(Icons.login),
-                          subtitle: const Text("登录后可以同步您的所有数据"),
-                          trailing: const Icon(Icons.chevron_right),
-                          onTap: () {
-                            Get.toNamed(RoutePath.kRemoteSyncWebDavConfig);
-                          },
-                        ),
-                      ]
-                    : [
-                        ListTile(
-                          title: const Text("已登录"),
-                          leading: const Icon(Icons.cloud_circle_outlined),
-                          subtitle: Text(controller.user.value),
-                          trailing: const Icon(Icons.logout),
-                          onTap: () {
-                            controller.onLogout();
-                          },
-                        ),
-                        AppStyle.divider,
-                        Obx(
-                          () => ListTile(
-                            title: const Text("云端备份目录"),
-                            leading: const Icon(Icons.drive_folder_upload),
-                            subtitle:
-                                Text(controller.webDavBackupDirectory.value),
-                            trailing: const Icon(Icons.chevron_right),
-                            onTap: _showEditBackupDirectory,
-                          ),
-                        ),
-                        AppStyle.divider,
-                        ListTile(
-                          title: const Text("上传到云端"),
-                          subtitle: Text("上次上传：${controller.lastUploadTime}"),
-                          leading: const Icon(Icons.cloud_upload_outlined),
-                          trailing: const Icon(Icons.chevron_right),
-                          onTap: () {
-                            controller.doWebDAVUpload();
-                          },
-                        ),
-                        AppStyle.divider,
-                        ListTile(
-                          title: const Text("恢复到本地"),
-                          subtitle: Text("上次恢复：${controller.lastRecoverTime}"),
-                          leading: const Icon(Icons.cloud_download_outlined),
-                          trailing: Row(
-                            mainAxisSize: MainAxisSize.min,
-                            children: [
-                              IconButton(
-                                icon: const Icon(Icons.settings),
-                                onPressed: showSetting,
+      appBar: AppBar(title: const Text('WebDAV同步')),
+      body: Align(
+        alignment: Alignment.topCenter,
+        child: ConstrainedBox(
+          constraints: const BoxConstraints(maxWidth: 800),
+          child: ListView(
+            padding: const EdgeInsets.fromLTRB(16, 12, 16, 32),
+            children: [
+              const _SectionHeading(title: '账号与备份'),
+              SettingsCard(
+                child: Obx(
+                  () => Column(
+                    children: controller.notLogin.value
+                        ? [
+                            SettingsAction(
+                              title: '点击登录',
+                              subtitle: '登录后可以同步您的所有数据',
+                              leading: const Icon(Icons.login_rounded),
+                              onTap: () => Get.toNamed(
+                                RoutePath.kRemoteSyncWebDavConfig,
                               ),
-                              const Icon(Icons.chevron_right),
-                            ],
-                          ),
-                          onTap: () {
-                            controller.doWebDAVRecovery();
-                          },
-                          onLongPress: showSetting,
-                        ),
-                        AppStyle.divider,
-                        ListTile(
-                          title: const Text("双向同步数据"),
-                          subtitle: Text("上次同步：${controller.lastRecoverTime}"),
-                          leading: const Icon(Icons.cloud_sync_outlined),
-                          trailing: const Icon(Icons.chevron_right),
-                          onTap: () {
-                            controller.doWebDAVBidirectional();
-                          },
-                          onLongPress: showSetting,
-                        ),
-                      ],
+                            ),
+                          ]
+                        : [
+                            _SyncActionTile(
+                              title: '已登录',
+                              subtitle: controller.user.value,
+                              leading: const Icon(
+                                Icons.cloud_circle_outlined,
+                              ),
+                              trailing: const Icon(Icons.logout_rounded),
+                              onTap: controller.onLogout,
+                            ),
+                            AppStyle.divider,
+                            SettingsAction(
+                              title: '云端备份目录',
+                              value: controller.webDavBackupDirectory.value,
+                              leading: const Icon(Icons.drive_folder_upload),
+                              onTap: _showEditBackupDirectory,
+                            ),
+                            AppStyle.divider,
+                            SettingsAction(
+                              title: '上传到云端',
+                              subtitle:
+                                  '上次上传：${controller.lastUploadTime.value}',
+                              leading: const Icon(Icons.cloud_upload_outlined),
+                              onTap: controller.doWebDAVUpload,
+                            ),
+                            AppStyle.divider,
+                            _SyncActionTile(
+                              title: '恢复到本地',
+                              subtitle:
+                                  '上次恢复：${controller.lastRecoverTime.value}',
+                              leading: const Icon(Icons.cloud_download_outlined),
+                              showSettings: true,
+                              onSettings: showSetting,
+                              onTap: controller.doWebDAVRecovery,
+                              onLongPress: showSetting,
+                            ),
+                            AppStyle.divider,
+                            _SyncActionTile(
+                              title: '双向同步数据',
+                              subtitle:
+                                  '上次同步：${controller.lastRecoverTime.value}',
+                              leading: const Icon(Icons.cloud_sync_outlined),
+                              onTap: controller.doWebDAVBidirectional,
+                              onLongPress: showSetting,
+                            ),
+                          ],
+                  ),
+                ),
               ),
-            ),
+            ],
           ),
-        ],
+        ),
       ),
     );
   }
@@ -112,70 +102,156 @@ class RemoteSyncWebDAVPage extends GetView<RemoteSyncWebDAVController> {
         mainAxisSize: MainAxisSize.min,
         crossAxisAlignment: CrossAxisAlignment.stretch,
         children: [
-          AppStyle.divider,
           Obx(
             () => CheckboxListTile(
               secondary: const Icon(Remix.heart_line),
-              title: const Text("同步关注列表"),
+              title: const Text('同步关注列表'),
               value: controller.isSyncFollows.value,
               controlAffinity: ListTileControlAffinity.trailing,
-              onChanged: (value) => controller.changeIsSyncFollows(),
+              onChanged: (_) => controller.changeIsSyncFollows(),
             ),
           ),
           AppStyle.divider,
           Obx(
             () => CheckboxListTile(
-              secondary: const Icon(Icons.history),
-              title: const Text("同步播放历史记录"),
+              secondary: const Icon(Icons.history_rounded),
+              title: const Text('同步播放历史记录'),
               value: controller.isSyncHistories.value,
               controlAffinity: ListTileControlAffinity.trailing,
-              onChanged: (value) => controller.changeIsSyncHistories(),
+              onChanged: (_) => controller.changeIsSyncHistories(),
             ),
           ),
           AppStyle.divider,
           Obx(
             () => CheckboxListTile(
               secondary: const Icon(Remix.shield_keyhole_line),
-              title: const Text("同步屏蔽字"),
+              title: const Text('同步屏蔽字'),
               value: controller.isSyncBlockWord.value,
               controlAffinity: ListTileControlAffinity.trailing,
-              onChanged: (value) => controller.changeIsSyncBlockWord(),
+              onChanged: (_) => controller.changeIsSyncBlockWord(),
             ),
           ),
           AppStyle.divider,
           Obx(
             () => CheckboxListTile(
               secondary: const Icon(Remix.account_circle_line),
-              title: const Text("同步用户平台账号"),
+              title: const Text('同步用户平台账号'),
               value: controller.isSyncAccount.value,
               controlAffinity: ListTileControlAffinity.trailing,
-              onChanged: (value) => controller.changeIsSyncAccount(),
+              onChanged: (_) => controller.changeIsSyncAccount(),
             ),
           ),
           AppStyle.divider,
           Obx(
             () => CheckboxListTile(
               secondary: const Icon(Remix.user_settings_line),
-              title: const Text("同步用户设置"),
+              title: const Text('同步用户设置'),
               value: controller.isSyncSetting.value,
               controlAffinity: ListTileControlAffinity.trailing,
-              onChanged: (value) => controller.changeIsSyncSetting(),
+              onChanged: (_) => controller.changeIsSyncSetting(),
             ),
           ),
-          //todo: 启动应用时自动同步数据
         ],
       ),
     );
   }
 
   void _showEditBackupDirectory() async {
-    var directory = await Utils.showEditTextDialog(
+    final directory = await Utils.showEditTextDialog(
       controller.webDavBackupDirectory.value,
-      title: "修改远程备份文件夹",
+      title: '修改远程备份文件夹',
     );
-    if (directory == null || directory.isEmpty) {
-      return;
-    }
+    if (directory == null || directory.isEmpty) return;
     controller.setWebDavBackupDirectory(newDirectory: directory);
+  }
+}
+
+class _SyncActionTile extends StatelessWidget {
+  const _SyncActionTile({
+    required this.title,
+    required this.leading,
+    this.subtitle,
+    this.trailing,
+    this.showSettings = false,
+    this.onTap,
+    this.onLongPress,
+    this.onSettings,
+  });
+
+  final String title;
+  final String? subtitle;
+  final Widget leading;
+  final Widget? trailing;
+  final bool showSettings;
+  final Function()? onTap;
+  final Function()? onLongPress;
+  final Function()? onSettings;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final semantic = context.appTheme;
+    return ListTile(
+      visualDensity: VisualDensity.compact,
+      minVerticalPadding: 10,
+      contentPadding: const EdgeInsets.only(left: 16, right: 8),
+      leading: leading,
+      title: Text(
+        title,
+        style: theme.textTheme.titleSmall?.copyWith(
+          color: semantic.textPrimary,
+          fontWeight: FontWeight.w600,
+        ),
+      ),
+      subtitle: subtitle == null
+          ? null
+          : Text(
+              subtitle!,
+              maxLines: 2,
+              overflow: TextOverflow.ellipsis,
+              style: theme.textTheme.bodySmall?.copyWith(
+                color: semantic.textSecondary,
+              ),
+            ),
+      trailing: trailing ??
+          Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              if (showSettings)
+                IconButton(
+                  tooltip: '同步选项',
+                  onPressed: onSettings,
+                  icon: const Icon(Icons.settings_outlined),
+                ),
+              Icon(
+                Icons.chevron_right_rounded,
+                color: semantic.textTertiary,
+              ),
+            ],
+          ),
+      onTap: onTap,
+      onLongPress: onLongPress,
+    );
+  }
+}
+
+class _SectionHeading extends StatelessWidget {
+  const _SectionHeading({required this.title});
+
+  final String title;
+
+  @override
+  Widget build(BuildContext context) {
+    final semantic = context.appTheme;
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(4, 0, 4, AppDesignTokens.space8),
+      child: Text(
+        title,
+        style: Theme.of(context).textTheme.titleSmall?.copyWith(
+          color: semantic.textSecondary,
+          fontWeight: FontWeight.w700,
+        ),
+      ),
+    );
   }
 }

--- a/simple_live_app/lib/modules/sync/sync_page.dart
+++ b/simple_live_app/lib/modules/sync/sync_page.dart
@@ -1,8 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import 'package:remixicon/remixicon.dart';
-import 'package:simple_live_app/app/app_style.dart';
+import 'package:simple_live_app/app/design_system/app_design_tokens.dart';
+import 'package:simple_live_app/app/design_system/app_theme_extension.dart';
 import 'package:simple_live_app/routes/route_path.dart';
+import 'package:simple_live_app/widgets/settings/settings_action.dart';
 import 'package:simple_live_app/widgets/settings/settings_card.dart';
 
 class SyncPage extends StatelessWidget {
@@ -12,16 +14,14 @@ class SyncPage extends StatelessWidget {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: const Text("数据同步"),
+        title: const Text('数据同步'),
         actions: [
           Visibility(
             visible: GetPlatform.isAndroid || GetPlatform.isIOS,
             child: TextButton.icon(
               onPressed: () async {
-                var result = await Get.toNamed(RoutePath.kSyncScan);
-                if (result == null || result.isEmpty) {
-                  return;
-                }
+                final result = await Get.toNamed(RoutePath.kSyncScan);
+                if (result == null || result.isEmpty) return;
                 if (result.length == 5) {
                   Get.toNamed(RoutePath.kRemoteSyncRoom, arguments: result);
                 } else {
@@ -29,59 +29,62 @@ class SyncPage extends StatelessWidget {
                 }
               },
               icon: const Icon(Remix.qr_scan_line),
-              label: const Text("扫一扫"),
+              label: const Text('扫一扫'),
             ),
           ),
+          const SizedBox(width: AppDesignTokens.space8),
         ],
       ),
-      body: ListView(
-        padding: AppStyle.edgeInsetsA12,
-        children: [
-          Padding(
-            padding: AppStyle.edgeInsetsA12.copyWith(top: 0),
-            child: Text(
-              "远程同步",
-              style: Get.textTheme.titleSmall,
-            ),
-          ),
-          SettingsCard(
-            child: Column(
-              children: [
-                ListTile(
-                  title: const Text("WebDAV"),
+      body: Align(
+        alignment: Alignment.topCenter,
+        child: ConstrainedBox(
+          constraints: const BoxConstraints(maxWidth: 800),
+          child: ListView(
+            padding: const EdgeInsets.fromLTRB(16, 12, 16, 32),
+            children: [
+              const _SectionHeading(title: '远程同步'),
+              SettingsCard(
+                child: SettingsAction(
                   leading: const Icon(Icons.cloud_upload_outlined),
-                  subtitle: const Text("通过WebDAV同步数据"),
-                  trailing: const Icon(Icons.chevron_right),
-                  onTap: () {
-                    Get.toNamed(RoutePath.kRemoteSyncWebDav);
-                  },
+                  title: 'WebDAV',
+                  subtitle: '通过 WebDAV 在不同设备间备份和恢复数据',
+                  onTap: () => Get.toNamed(RoutePath.kRemoteSyncWebDav),
                 ),
-              ],
-            ),
-          ),
-          Padding(
-            padding: AppStyle.edgeInsetsA12.copyWith(top: 24),
-            child: Text(
-              "局域网同步",
-              style: Get.textTheme.titleSmall,
-            ),
-          ),
-          SettingsCard(
-            child: Column(
-              children: [
-                ListTile(
-                  title: const Text("局域网同步"),
-                  subtitle: const Text("在局域网内同步数据"),
+              ),
+              const _SectionHeading(title: '局域网同步', top: 24),
+              SettingsCard(
+                child: SettingsAction(
                   leading: const Icon(Remix.device_line),
-                  trailing: const Icon(Icons.chevron_right),
-                  onTap: () {
-                    Get.toNamed(RoutePath.kLocalSync);
-                  },
+                  title: '局域网同步',
+                  subtitle: '发现同一局域网内的 Slive 设备并发送数据',
+                  onTap: () => Get.toNamed(RoutePath.kLocalSync),
                 ),
-              ],
-            ),
+              ),
+            ],
           ),
-        ],
+        ),
+      ),
+    );
+  }
+}
+
+class _SectionHeading extends StatelessWidget {
+  const _SectionHeading({required this.title, this.top = 0});
+
+  final String title;
+  final double top;
+
+  @override
+  Widget build(BuildContext context) {
+    final semantic = context.appTheme;
+    return Padding(
+      padding: EdgeInsets.fromLTRB(4, top, 4, AppDesignTokens.space8),
+      child: Text(
+        title,
+        style: Theme.of(context).textTheme.titleSmall?.copyWith(
+          color: semantic.textSecondary,
+          fontWeight: FontWeight.w700,
+        ),
       ),
     );
   }

--- a/simple_live_app/lib/widgets/desktop_refresh_button.dart
+++ b/simple_live_app/lib/widgets/desktop_refresh_button.dart
@@ -1,41 +1,49 @@
 import 'package:flutter/material.dart';
-import 'package:simple_live_app/app/app_style.dart';
+import 'package:simple_live_app/app/design_system/app_design_tokens.dart';
+import 'package:simple_live_app/app/design_system/app_theme_extension.dart';
 
 class DesktopRefreshButton extends StatelessWidget {
   final bool refreshing;
   final Function()? onPressed;
-  const DesktopRefreshButton(
-      {required this.refreshing, this.onPressed, super.key});
+
+  const DesktopRefreshButton({
+    required this.refreshing,
+    this.onPressed,
+    super.key,
+  });
 
   @override
   Widget build(BuildContext context) {
-    return Container(
-      decoration: BoxDecoration(
-        color: Theme.of(context).cardColor,
-        borderRadius: AppStyle.radius48,
-        boxShadow: [
-          BoxShadow(
-            color: Colors.grey.withAlpha(50),
-            blurRadius: 4,
-          ),
-        ],
+    final semantic = context.appTheme;
+    final theme = Theme.of(context);
+
+    return Material(
+      color: semantic.elevatedSurface,
+      elevation: 0,
+      shadowColor: semantic.shadow,
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(AppDesignTokens.radius12),
+        side: BorderSide(color: semantic.border),
       ),
-      width: 40,
-      height: 40,
-      child: refreshing
-          ? const Center(
-              child: SizedBox(
-                width: 20,
-                height: 20,
-                child: CircularProgressIndicator(
-                  strokeWidth: 2,
+      child: SizedBox.square(
+        dimension: 44,
+        child: refreshing
+            ? Center(
+                child: SizedBox.square(
+                  dimension: 20,
+                  child: CircularProgressIndicator(
+                    strokeWidth: 2,
+                    color: theme.colorScheme.primary,
+                    semanticsLabel: '正在刷新',
+                  ),
                 ),
+              )
+            : IconButton(
+                onPressed: onPressed,
+                tooltip: '刷新',
+                icon: const Icon(Icons.refresh_rounded),
               ),
-            )
-          : IconButton(
-              onPressed: onPressed,
-              icon: const Icon(Icons.refresh),
-            ),
+      ),
     );
   }
 }

--- a/simple_live_app/lib/widgets/filter_button.dart
+++ b/simple_live_app/lib/widgets/filter_button.dart
@@ -1,10 +1,11 @@
 import 'package:flutter/material.dart';
-import 'package:simple_live_app/app/app_style.dart';
+import 'package:simple_live_app/app/design_system/app_theme_extension.dart';
 
 class FilterButton extends StatelessWidget {
   final bool selected;
   final String text;
   final Function()? onTap;
+
   const FilterButton({
     this.selected = false,
     required this.text,
@@ -14,26 +15,51 @@ class FilterButton extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return InkWell(
-      borderRadius: AppStyle.radius24,
-      onTap: onTap,
-      child: Container(
-        padding: AppStyle.edgeInsetsH12.copyWith(top: 4, bottom: 4),
-        decoration: BoxDecoration(
-          border: Border.all(
-              color: selected
-                  ? Theme.of(context).textTheme.bodyMedium!.color!
-                  : Colors.grey),
-          borderRadius: AppStyle.radius24,
+    final theme = Theme.of(context);
+    final semantic = context.appTheme;
+    final radius = BorderRadius.circular(999);
+    final foreground = selected
+        ? theme.colorScheme.primary
+        : semantic.textSecondary;
+
+    final shape = RoundedRectangleBorder(
+      borderRadius: radius,
+      side: BorderSide(
+        color: selected
+            ? theme.colorScheme.primary.withAlpha(90)
+            : semantic.border,
+      ),
+    );
+    final content = Container(
+      constraints: const BoxConstraints(minHeight: 44),
+      padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 8),
+      alignment: Alignment.center,
+      child: Text(
+        text,
+        style: theme.textTheme.labelLarge?.copyWith(
+          color: foreground,
+          fontWeight: selected ? FontWeight.w700 : FontWeight.w600,
         ),
-        child: Text(
-          text,
-          style: selected
-              ? Theme.of(context).textTheme.bodyMedium
-              : Theme.of(context).textTheme.bodyMedium!.copyWith(
-                    color: Colors.grey,
-                  ),
-        ),
+      ),
+    );
+
+    return Semantics(
+      button: onTap != null,
+      selected: selected,
+      child: Material(
+        color: selected
+            ? theme.colorScheme.primary.withAlpha(18)
+            : semantic.secondarySurface,
+        shape: shape,
+        clipBehavior: Clip.antiAlias,
+        child: onTap == null
+            ? content
+            : InkWell(
+                onTap: onTap,
+                focusColor: theme.colorScheme.primary.withAlpha(18),
+                hoverColor: theme.colorScheme.primary.withAlpha(12),
+                child: content,
+              ),
       ),
     );
   }

--- a/simple_live_app/lib/widgets/follow_user_item.dart
+++ b/simple_live_app/lib/widgets/follow_user_item.dart
@@ -1,11 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import 'package:remixicon/remixicon.dart';
-import 'package:simple_live_app/app/app_style.dart';
+import 'package:simple_live_app/app/design_system/app_theme_extension.dart';
 import 'package:simple_live_app/app/sites.dart';
 import 'package:simple_live_app/models/db/follow_user.dart';
 import 'package:simple_live_app/widgets/net_image.dart';
-import 'dart:ui' as ui;
 
 class FollowUserItem extends StatelessWidget {
   final FollowUser item;
@@ -13,6 +12,7 @@ class FollowUserItem extends StatelessWidget {
   final Function()? onTap;
   final Function()? onLongPress;
   final bool playing;
+
   const FollowUserItem({
     required this.item,
     this.onRemove,
@@ -24,107 +24,81 @@ class FollowUserItem extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    var site = Sites.allSites[item.siteId]!;
+    final site = Sites.allSites[item.siteId]!;
+    final semantic = context.appTheme;
+    final theme = Theme.of(context);
+
     return ListTile(
-      contentPadding: AppStyle.edgeInsetsL16.copyWith(right: 4),
+      minVerticalPadding: 8,
+      contentPadding: const EdgeInsets.only(left: 16, right: 8),
       leading: NetImage(
         item.face,
         width: 48,
         height: 48,
         borderRadius: 24,
       ),
-      title: Text.rich(
-        TextSpan(
-          text: item.remark?.isNotEmpty == true ? item.remark : item.userName,
+      title: Row(
+        children: [
+          Expanded(
+            child: Text(
+              item.remark?.isNotEmpty == true ? item.remark! : item.userName,
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+              style: theme.textTheme.titleSmall?.copyWith(
+                color: semantic.textPrimary,
+                fontWeight: FontWeight.w700,
+              ),
+            ),
+          ),
+          const SizedBox(width: 8),
+          Obx(() => _LiveStatus(status: item.liveStatus.value)),
+        ],
+      ),
+      subtitle: Padding(
+        padding: const EdgeInsets.only(top: 4),
+        child: Row(
           children: [
-            WidgetSpan(
-              alignment: ui.PlaceholderAlignment.middle,
-              child: Obx(
-                () => Offstage(
-                  offstage: item.liveStatus.value == 0,
-                  child: Row(
-                    mainAxisSize: MainAxisSize.min,
-                    children: [
-                      AppStyle.hGap12,
-                      Container(
-                        width: 8,
-                        height: 8,
-                        decoration: BoxDecoration(
-                          color: item.liveStatus.value == 2
-                              ? Colors.green
-                              : Colors.grey,
-                          borderRadius: AppStyle.radius12,
-                        ),
-                      ),
-                      AppStyle.hGap4,
-                      Text(
-                        getStatus(item.liveStatus.value),
-                        style: TextStyle(
-                          fontSize: 12,
-                          fontWeight: FontWeight.normal,
-                          color:
-                              item.liveStatus.value == 2 ? null : Colors.grey,
-                        ),
-                      ),
-                    ],
-                  ),
+            Image.asset(site.logo, width: 16, height: 16),
+            const SizedBox(width: 4),
+            Flexible(
+              child: Text(
+                [
+                  site.name,
+                  item.watchDuration ?? '00:00:00',
+                  item.tag.length > 8
+                      ? '${item.tag.substring(0, 8)}...'
+                      : item.tag,
+                ].where((text) => text.isNotEmpty).join(' · '),
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+                style: theme.textTheme.bodySmall?.copyWith(
+                  color: semantic.textSecondary,
                 ),
               ),
             ),
           ],
         ),
       ),
-      subtitle: Wrap(
-        runSpacing: 1.0,
-        children: [
-          Image.asset(
-            site.logo,
-            width: 20,
-          ),
-          AppStyle.hGap4,
-          Text(
-            site.name,
-            style: const TextStyle(
-              fontSize: 12,
-              color: Colors.grey,
-            ),
-          ),
-          AppStyle.hGap4,
-          Text(
-            item.watchDuration ?? "00:00:00",
-            style: const TextStyle(
-              fontSize: 12,
-              color: Colors.grey,
-            ),
-          ),
-          AppStyle.hGap4,
-          Text(
-            item.tag.length > 8 ? '${item.tag.substring(0, 8)}...' : item.tag,
-            style: const TextStyle(
-              fontSize: 12,
-              color: Colors.grey,
-            ),
-            maxLines: 1,
-            overflow: TextOverflow.ellipsis,
-          ),
-        ],
-      ),
       trailing: playing
-          ? const SizedBox(
-              width: 64,
-              child: Center(
-                child: Icon(
-                  Icons.play_arrow,
-                ),
+          ? SizedBox(
+              width: 44,
+              height: 44,
+              child: Icon(
+                Icons.equalizer_rounded,
+                color: theme.colorScheme.primary,
+                semanticLabel: '正在播放',
               ),
             )
           : (onRemove == null
               ? null
               : IconButton(
-                  onPressed: () {
-                    onRemove?.call();
-                  },
-                  icon: const Icon(Remix.dislike_line),
+                  onPressed: onRemove,
+                  tooltip: '取消关注',
+                  constraints: const BoxConstraints(
+                    minWidth: 44,
+                    minHeight: 44,
+                  ),
+                  icon: const Icon(Remix.dislike_line, size: 20),
                 )),
       onTap: onTap,
       onLongPress: onLongPress,
@@ -133,11 +107,66 @@ class FollowUserItem extends StatelessWidget {
 
   String getStatus(int status) {
     if (status == 0) {
-      return "读取中";
+      return '读取中';
     } else if (status == 1) {
-      return "未开播";
+      return '未开播';
     } else {
-      return "直播中";
+      return '直播中';
     }
+  }
+}
+
+class _LiveStatus extends StatelessWidget {
+  const _LiveStatus({required this.status});
+
+  final int status;
+
+  @override
+  Widget build(BuildContext context) {
+    if (status == 0) {
+      return const SizedBox.shrink();
+    }
+
+    final theme = Theme.of(context);
+    final semantic = context.appTheme;
+    final isLive = status == 2;
+    final color = isLive ? theme.colorScheme.primary : semantic.textTertiary;
+
+    return Semantics(
+      label: isLive ? '直播中' : '未开播',
+      child: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 7, vertical: 3),
+        decoration: BoxDecoration(
+          color: isLive
+              ? theme.colorScheme.primary.withAlpha(18)
+              : semantic.secondarySurface,
+          borderRadius: BorderRadius.circular(999),
+          border: Border.all(
+            color: isLive
+                ? theme.colorScheme.primary.withAlpha(54)
+                : semantic.border,
+          ),
+        ),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(
+              isLive ? Icons.sensors_rounded : Icons.pause_circle_outline,
+              size: 12,
+              color: color,
+            ),
+            const SizedBox(width: 3),
+            Text(
+              isLive ? '直播中' : '未开播',
+              style: theme.textTheme.labelSmall?.copyWith(
+                color: color,
+                fontWeight: FontWeight.w600,
+                height: 1,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
   }
 }

--- a/simple_live_app/lib/widgets/live_room_card.dart
+++ b/simple_live_app/lib/widgets/live_room_card.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:remixicon/remixicon.dart';
 import 'package:simple_live_app/app/app_style.dart';
+import 'package:simple_live_app/app/design_system/app_theme_extension.dart';
 import 'package:simple_live_app/app/sites.dart';
 import 'package:simple_live_app/app/utils.dart';
 import 'package:simple_live_app/routes/app_navigation.dart';
@@ -13,10 +14,20 @@ class LiveRoomCard extends StatelessWidget {
   final LiveRoomItem item;
   final Function()? onLongPress;
   final Function()? onFollowRemove;
-  const LiveRoomCard(this.site, this.item, {super.key, this.onLongPress, this.onFollowRemove});
+
+  const LiveRoomCard(
+    this.site,
+    this.item, {
+    super.key,
+    this.onLongPress,
+    this.onFollowRemove,
+  });
 
   @override
   Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final semantic = context.appTheme;
+
     return ShadowCard(
       onTap: () {
         AppNavigator.toLiveRoomDetail(site: site, roomId: item.roomId);
@@ -25,67 +36,65 @@ class LiveRoomCard extends StatelessWidget {
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          Stack(
-            children: [
-              ClipRRect(
-                borderRadius: const BorderRadius.only(
-                  topLeft: Radius.circular(8),
-                  topRight: Radius.circular(8),
-                ),
-                child: NetImage(
+          AspectRatio(
+            aspectRatio: 16 / 9,
+            child: Stack(
+              fit: StackFit.expand,
+              children: [
+                NetImage(
                   item.cover,
                   fit: BoxFit.cover,
-                  height: 110,
-                  width: double.infinity,
                 ),
-              ),
-              Positioned(
-                right: 0,
-                left: 0,
-                bottom: 0,
-                child: Container(
-                  padding: const EdgeInsets.symmetric(
-                    horizontal: 4,
-                    vertical: 8,
-                  ),
-                  decoration: const BoxDecoration(
+                const DecoratedBox(
+                  decoration: BoxDecoration(
                     gradient: LinearGradient(
-                      begin: Alignment.bottomCenter,
-                      end: Alignment.topCenter,
-                      colors: [
-                        Colors.black87,
-                        Colors.transparent,
-                      ],
+                      begin: Alignment.topCenter,
+                      end: Alignment.bottomCenter,
+                      stops: [0.48, 1],
+                      colors: [Colors.transparent, Color(0xCC000000)],
                     ),
                   ),
+                ),
+                Positioned(
+                  left: 10,
+                  right: 10,
+                  bottom: 8,
                   child: Row(
-                    mainAxisAlignment: MainAxisAlignment.end,
                     children: [
-                      Icon(
-                        site.iconData,
+                      Icon(site.iconData, color: Colors.white, size: 14),
+                      AppStyle.hGap4,
+                      Expanded(
+                        child: Text(
+                          site.name,
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
+                          style: theme.textTheme.labelSmall?.copyWith(
+                            color: Colors.white,
+                            fontWeight: FontWeight.w600,
+                          ),
+                        ),
+                      ),
+                      const Icon(
+                        Icons.visibility_outlined,
                         color: Colors.white,
                         size: 14,
                       ),
                       AppStyle.hGap4,
                       Text(
                         Utils.onlineToString(item.online),
-                        style: const TextStyle(
-                          fontSize: 12,
+                        style: theme.textTheme.labelSmall?.copyWith(
                           color: Colors.white,
+                          fontWeight: FontWeight.w600,
                         ),
-                      )
+                      ),
                     ],
                   ),
                 ),
-              ),
-            ],
-          ),
-          // like ListTitle, but listTile is oversized
-          Padding(
-            padding: AppStyle.edgeInsetsH8.copyWith(
-              top: 8,
-              bottom: 8,
+              ],
             ),
+          ),
+          Padding(
+            padding: const EdgeInsets.fromLTRB(12, 10, 8, 10),
             child: Row(
               crossAxisAlignment: CrossAxisAlignment.center,
               children: [
@@ -96,36 +105,42 @@ class LiveRoomCard extends StatelessWidget {
                     children: [
                       Text(
                         item.title,
-                        maxLines: 1,
+                        maxLines: 2,
                         overflow: TextOverflow.ellipsis,
+                        style: theme.textTheme.titleSmall?.copyWith(
+                          color: semantic.textPrimary,
+                          fontWeight: FontWeight.w700,
+                          height: 1.25,
+                        ),
                       ),
-                      const SizedBox(height: 2),
+                      AppStyle.vGap4,
                       Text(
                         item.userName,
                         maxLines: 1,
                         overflow: TextOverflow.ellipsis,
-                        style: const TextStyle(
-                          height: 1.4,
-                          fontSize: 12,
-                          color: Colors.grey,
+                        style: theme.textTheme.bodySmall?.copyWith(
+                          color: semantic.textSecondary,
+                          height: 1.2,
                         ),
                       ),
                     ],
                   ),
                 ),
                 if (onFollowRemove != null) ...[
-                  const SizedBox(width: 4),
+                  AppStyle.hGap4,
                   IconButton(
                     onPressed: onFollowRemove,
-                    visualDensity: VisualDensity.compact,
-                    padding: EdgeInsets.zero,
-                    constraints: const BoxConstraints(),
-                    icon: const Icon(Remix.dislike_line),
-                  )
-                ]
+                    tooltip: '取消关注',
+                    constraints: const BoxConstraints(
+                      minWidth: 44,
+                      minHeight: 44,
+                    ),
+                    icon: const Icon(Remix.dislike_line, size: 20),
+                  ),
+                ],
               ],
             ),
-          )
+          ),
         ],
       ),
     );

--- a/simple_live_app/lib/widgets/net_image.dart
+++ b/simple_live_app/lib/widgets/net_image.dart
@@ -1,5 +1,6 @@
 import 'package:extended_image/extended_image.dart';
 import 'package:flutter/material.dart';
+import 'package:simple_live_app/app/design_system/app_theme_extension.dart';
 
 class NetImage extends StatelessWidget {
   final String picUrl;
@@ -7,52 +8,95 @@ class NetImage extends StatelessWidget {
   final double? height;
   final BoxFit? fit;
   final double borderRadius;
-  const NetImage(this.picUrl,
-      {this.width,
-      this.height,
-      this.fit = BoxFit.cover,
-      this.borderRadius = 0,
-      super.key});
+
+  const NetImage(
+    this.picUrl, {
+    this.width,
+    this.height,
+    this.fit = BoxFit.cover,
+    this.borderRadius = 0,
+    super.key,
+  });
 
   @override
   Widget build(BuildContext context) {
+    final radius = BorderRadius.circular(borderRadius);
     if (picUrl.isEmpty) {
-      return Image.asset(
-        'assets/images/logo.png',
-        width: width,
-        height: height,
+      return ClipRRect(
+        borderRadius: radius,
+        child: Image.asset(
+          'assets/images/logo.png',
+          width: width,
+          height: height,
+        ),
       );
     }
+
     var pic = picUrl;
-    if (pic.startsWith("//")) {
+    if (pic.startsWith('//')) {
       pic = 'https:$pic';
     }
+
     return ClipRRect(
-      borderRadius: BorderRadius.circular(borderRadius),
+      borderRadius: radius,
       child: ExtendedImage.network(
         pic,
         fit: fit,
         height: height,
         width: width,
         shape: BoxShape.rectangle,
-        borderRadius: BorderRadius.circular(borderRadius),
-        loadStateChanged: (e) {
-          if (e.extendedImageLoadState == LoadState.loading) {
-            return const Icon(
-              Icons.image,
-              color: Colors.grey,
-              size: 24,
-            );
+        borderRadius: radius,
+        loadStateChanged: (state) {
+          switch (state.extendedImageLoadState) {
+            case LoadState.loading:
+              return _ImageState(
+                width: width,
+                height: height,
+                icon: Icons.image_outlined,
+                semanticLabel: '图片加载中',
+              );
+            case LoadState.failed:
+              return _ImageState(
+                width: width,
+                height: height,
+                icon: Icons.broken_image_outlined,
+                semanticLabel: '图片加载失败',
+              );
+            case LoadState.completed:
+              return null;
           }
-          if (e.extendedImageLoadState == LoadState.failed) {
-            return const Icon(
-              Icons.broken_image,
-              color: Colors.grey,
-              size: 24,
-            );
-          }
-          return null;
         },
+      ),
+    );
+  }
+}
+
+class _ImageState extends StatelessWidget {
+  const _ImageState({
+    required this.width,
+    required this.height,
+    required this.icon,
+    required this.semanticLabel,
+  });
+
+  final double? width;
+  final double? height;
+  final IconData icon;
+  final String semanticLabel;
+
+  @override
+  Widget build(BuildContext context) {
+    final semantic = context.appTheme;
+    return Container(
+      width: width,
+      height: height,
+      color: semantic.secondarySurface,
+      alignment: Alignment.center,
+      child: Icon(
+        icon,
+        color: semantic.textTertiary,
+        size: 24,
+        semanticLabel: semanticLabel,
       ),
     );
   }

--- a/simple_live_app/lib/widgets/none_border_circular_textfield.dart
+++ b/simple_live_app/lib/widgets/none_border_circular_textfield.dart
@@ -1,4 +1,6 @@
 import 'package:flutter/material.dart';
+import 'package:simple_live_app/app/design_system/app_design_tokens.dart';
+import 'package:simple_live_app/app/design_system/app_theme_extension.dart';
 
 class NoneBorderCircularTextField extends StatelessWidget {
   final TextEditingController editingController;
@@ -19,7 +21,6 @@ class NoneBorderCircularTextField extends StatelessWidget {
   final FocusNode? focusNode;
   final bool? enable;
   final bool readOnly;
-
   final bool needPadding;
 
   const NoneBorderCircularTextField({
@@ -47,25 +48,59 @@ class NoneBorderCircularTextField extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    TextField common = TextField(
+    final theme = Theme.of(context);
+    final semantic = context.appTheme;
+    final radius = BorderRadius.circular(AppDesignTokens.radius12);
+    final common = TextField(
       enabled: enable,
       readOnly: readOnly,
       decoration: InputDecoration(
         prefixIcon: prefixIcon,
         hintText: hintText,
         filled: true,
-        contentPadding: const EdgeInsets.symmetric(vertical: 4, horizontal: 12),
+        fillColor: semantic.secondarySurface,
+        contentPadding: const EdgeInsets.symmetric(
+          vertical: 12,
+          horizontal: 14,
+        ),
         suffix: trailing,
         helperText: helperText,
         helperMaxLines: 3,
         border: OutlineInputBorder(
           borderSide: BorderSide.none,
-          borderRadius: const BorderRadius.all(Radius.circular(8.0)),
+          borderRadius: radius,
+        ),
+        enabledBorder: OutlineInputBorder(
+          borderSide: BorderSide(color: semantic.border),
+          borderRadius: radius,
+        ),
+        focusedBorder: OutlineInputBorder(
+          borderSide: BorderSide(
+            color: theme.colorScheme.primary,
+            width: 1.5,
+          ),
+          borderRadius: radius,
+        ),
+        disabledBorder: OutlineInputBorder(
+          borderSide: BorderSide(color: semantic.divider),
+          borderRadius: radius,
+        ),
+        errorBorder: OutlineInputBorder(
+          borderSide: BorderSide(color: theme.colorScheme.error),
+          borderRadius: radius,
+        ),
+        focusedErrorBorder: OutlineInputBorder(
+          borderSide: BorderSide(
+            color: theme.colorScheme.error,
+            width: 1.5,
+          ),
+          borderRadius: radius,
         ),
         labelText: labelText,
         errorText: errorText,
         errorMaxLines: 3,
       ),
+      cursorColor: theme.colorScheme.primary,
       textAlign: textAlign,
       autofocus: autoFocus,
       keyboardType: inputType,
@@ -77,16 +112,13 @@ class NoneBorderCircularTextField extends StatelessWidget {
       onTap: onTap,
       focusNode: focusNode,
     );
-    if (needPadding) {
-      return Padding(
-        padding: const EdgeInsets.only(
-          top: 10,
-          bottom: 10,
-        ),
-        child: common,
-      );
-    } else {
+
+    if (!needPadding) {
       return common;
     }
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 10),
+      child: common,
+    );
   }
 }

--- a/simple_live_app/lib/widgets/page_grid_view.dart
+++ b/simple_live_app/lib/widgets/page_grid_view.dart
@@ -1,13 +1,14 @@
 import 'dart:io';
 
 import 'package:flutter/material.dart';
+import 'package:flutter_easyrefresh/easy_refresh.dart';
+import 'package:flutter_staggered_grid_view/flutter_staggered_grid_view.dart';
+import 'package:get/get.dart';
 import 'package:simple_live_app/app/controller/base_controller.dart';
+import 'package:simple_live_app/widgets/desktop_refresh_button.dart';
 import 'package:simple_live_app/widgets/status/app_empty_widget.dart';
 import 'package:simple_live_app/widgets/status/app_error_widget.dart';
 import 'package:simple_live_app/widgets/status/app_loadding_widget.dart';
-import 'package:flutter_staggered_grid_view/flutter_staggered_grid_view.dart';
-import 'package:flutter_easyrefresh/easy_refresh.dart';
-import 'package:get/get.dart';
 
 class PageGridView extends StatelessWidget {
   final BasePageController pageController;
@@ -19,6 +20,7 @@ class PageGridView extends StatelessWidget {
   final double crossAxisSpacing, mainAxisSpacing;
   final int crossAxisCount;
   final bool showPCRefreshButton;
+
   const PageGridView({
     required this.itemBuilder,
     required this.pageController,
@@ -33,97 +35,96 @@ class PageGridView extends StatelessWidget {
     super.key,
   });
 
+  bool get _isDesktop =>
+      Platform.isWindows || Platform.isLinux || Platform.isMacOS;
+
+  EdgeInsets? get _resolvedPadding {
+    if (!_isDesktop) return padding;
+    final contentPadding = padding ?? EdgeInsets.zero;
+    return contentPadding.copyWith(bottom: contentPadding.bottom + 72);
+  }
+
   @override
   Widget build(BuildContext context) {
     return Obx(
-      () => Stack(
-        children: [
-          EasyRefresh(
-            header: MaterialHeader(
-              completeDuration: const Duration(milliseconds: 400),
-            ),
-            footer: MaterialFooter(
-              completeDuration: const Duration(milliseconds: 400),
-            ),
-            scrollController: pageController.scrollController,
-            controller: pageController.easyRefreshController,
-            firstRefresh: firstRefresh,
-            onLoad: pageController.loadData,
-            onRefresh: pageController.refreshData,
-            child: MasonryGridView.count(
-              padding: padding,
-              itemCount: pageController.list.length,
-              itemBuilder: itemBuilder,
-              crossAxisCount: crossAxisCount,
-              crossAxisSpacing: crossAxisSpacing,
-              mainAxisSpacing: mainAxisSpacing,
-            ),
-          ),
-          Positioned(
-            bottom: 0,
-            left: 0,
-            right: 0,
-            child: // 加载更多按钮
-                Visibility(
-              visible: (Platform.isWindows ||
-                      Platform.isLinux ||
-                      Platform.isMacOS) &&
-                  pageController.canLoadMore.value &&
-                  !pageController.pageLoadding.value &&
-                  !pageController.pageEmpty.value,
-              child: Center(
-                child: TextButton(
-                  onPressed: pageController.loadData,
-                  child: const Text("加载更多"),
-                ),
+      () {
+        final showDesktopActions = _isDesktop &&
+            pageController.canLoadMore.value &&
+            !pageController.pageLoadding.value &&
+            !pageController.pageEmpty.value;
+
+        return Stack(
+          children: [
+            EasyRefresh(
+              header: MaterialHeader(
+                completeDuration: const Duration(milliseconds: 400),
+              ),
+              footer: MaterialFooter(
+                completeDuration: const Duration(milliseconds: 400),
+              ),
+              scrollController: pageController.scrollController,
+              controller: pageController.easyRefreshController,
+              firstRefresh: firstRefresh,
+              onLoad: pageController.loadData,
+              onRefresh: pageController.refreshData,
+              child: MasonryGridView.count(
+                padding: _resolvedPadding,
+                itemCount: pageController.list.length,
+                itemBuilder: itemBuilder,
+                crossAxisCount: crossAxisCount,
+                crossAxisSpacing: crossAxisSpacing,
+                mainAxisSpacing: mainAxisSpacing,
               ),
             ),
-          ),
-          Positioned(
-            bottom: 12,
-            right: 12,
-            child: // 加载更多按钮
-                Visibility(
-              visible: (Platform.isWindows ||
-                      Platform.isLinux ||
-                      Platform.isMacOS) &&
-                  pageController.canLoadMore.value &&
-                  !pageController.pageLoadding.value &&
-                  !pageController.pageEmpty.value &&
-                  showPCRefreshButton,
-              child: Center(
-                child: IconButton(
-                  style: IconButton.styleFrom(
-                    backgroundColor: Get.theme.cardColor.withAlpha(200),
-                    elevation: 4,
+            Positioned(
+              bottom: 8,
+              left: 0,
+              right: 0,
+              child: Visibility(
+                visible: showDesktopActions,
+                child: Center(
+                  child: FilledButton.tonal(
+                    style: FilledButton.styleFrom(
+                      minimumSize: const Size(0, 44),
+                    ),
+                    onPressed: pageController.loadData,
+                    child: const Text('加载更多'),
                   ),
-                  onPressed: () {
-                    pageController.refreshData();
-                  },
-                  icon: const Icon(Icons.refresh),
                 ),
               ),
             ),
-          ),
-          Offstage(
-            offstage: !pageController.pageEmpty.value,
-            child: AppEmptyWidget(
-              onRefresh: () => pageController.refreshData(),
+            Positioned(
+              bottom: 12,
+              right: 12,
+              child: Visibility(
+                visible: showDesktopActions && showPCRefreshButton,
+                child: DesktopRefreshButton(
+                  refreshing: false,
+                  onPressed: pageController.refreshData,
+                ),
+              ),
             ),
-          ),
-          Offstage(
-            offstage: !(showPageLoadding && pageController.pageLoadding.value),
-            child: const AppLoaddingWidget(),
-          ),
-          Offstage(
-            offstage: !pageController.pageError.value,
-            child: AppErrorWidget(
-              errorMsg: pageController.errorMsg.value,
-              onRefresh: () => pageController.refreshData(),
+            Offstage(
+              offstage: !pageController.pageEmpty.value,
+              child: AppEmptyWidget(
+                onRefresh: pageController.refreshData,
+              ),
             ),
-          ),
-        ],
-      ),
+            Offstage(
+              offstage:
+                  !(showPageLoadding && pageController.pageLoadding.value),
+              child: const AppLoaddingWidget(),
+            ),
+            Offstage(
+              offstage: !pageController.pageError.value,
+              child: AppErrorWidget(
+                errorMsg: pageController.errorMsg.value,
+                onRefresh: pageController.refreshData,
+              ),
+            ),
+          ],
+        );
+      },
     );
   }
 }

--- a/simple_live_app/lib/widgets/page_list_view.dart
+++ b/simple_live_app/lib/widgets/page_list_view.dart
@@ -1,13 +1,13 @@
 import 'dart:io';
 
 import 'package:flutter/material.dart';
+import 'package:flutter_easyrefresh/easy_refresh.dart';
+import 'package:get/get.dart';
 import 'package:simple_live_app/app/controller/base_controller.dart';
+import 'package:simple_live_app/widgets/desktop_refresh_button.dart';
 import 'package:simple_live_app/widgets/status/app_empty_widget.dart';
 import 'package:simple_live_app/widgets/status/app_error_widget.dart';
 import 'package:simple_live_app/widgets/status/app_loadding_widget.dart';
-
-import 'package:flutter_easyrefresh/easy_refresh.dart';
-import 'package:get/get.dart';
 
 typedef IndexedWidgetBuilder = Widget Function(BuildContext context, int index);
 
@@ -20,6 +20,7 @@ class PageListView extends StatelessWidget {
   final Function()? onLoginSuccess;
   final bool showPageLoadding;
   final bool showPCRefreshButton;
+
   const PageListView({
     required this.itemBuilder,
     required this.pageController,
@@ -32,96 +33,95 @@ class PageListView extends StatelessWidget {
     super.key,
   });
 
+  bool get _isDesktop =>
+      Platform.isWindows || Platform.isLinux || Platform.isMacOS;
+
+  EdgeInsets? get _resolvedPadding {
+    if (!_isDesktop) return padding;
+    final contentPadding = padding ?? EdgeInsets.zero;
+    return contentPadding.copyWith(bottom: contentPadding.bottom + 72);
+  }
+
   @override
   Widget build(BuildContext context) {
     return Obx(
-      () => Stack(
-        children: [
-          EasyRefresh(
-            header: MaterialHeader(
-              completeDuration: const Duration(milliseconds: 400),
-            ),
-            footer: MaterialFooter(
-              completeDuration: const Duration(milliseconds: 400),
-            ),
-            scrollController: pageController.scrollController,
-            controller: pageController.easyRefreshController,
-            firstRefresh: firstRefresh,
-            onLoad: pageController.loadData,
-            onRefresh: pageController.refreshData,
-            child: ListView.separated(
-              padding: padding,
-              itemCount: pageController.list.length,
-              itemBuilder: itemBuilder,
-              separatorBuilder:
-                  separatorBuilder ?? (context, i) => const SizedBox(),
-            ),
-          ),
-          Positioned(
-            bottom: 0,
-            left: 0,
-            right: 0,
-            child: // 加载更多按钮
-                Visibility(
-              visible: (Platform.isWindows ||
-                      Platform.isLinux ||
-                      Platform.isMacOS) &&
-                  pageController.canLoadMore.value &&
-                  !pageController.pageLoadding.value &&
-                  !pageController.pageEmpty.value,
-              child: Center(
-                child: TextButton(
-                  onPressed: pageController.loadData,
-                  child: const Text("加载更多"),
-                ),
+      () {
+        final showDesktopActions = _isDesktop &&
+            pageController.canLoadMore.value &&
+            !pageController.pageLoadding.value &&
+            !pageController.pageEmpty.value;
+
+        return Stack(
+          children: [
+            EasyRefresh(
+              header: MaterialHeader(
+                completeDuration: const Duration(milliseconds: 400),
+              ),
+              footer: MaterialFooter(
+                completeDuration: const Duration(milliseconds: 400),
+              ),
+              scrollController: pageController.scrollController,
+              controller: pageController.easyRefreshController,
+              firstRefresh: firstRefresh,
+              onLoad: pageController.loadData,
+              onRefresh: pageController.refreshData,
+              child: ListView.separated(
+                padding: _resolvedPadding,
+                itemCount: pageController.list.length,
+                itemBuilder: itemBuilder,
+                separatorBuilder:
+                    separatorBuilder ?? (context, index) => const SizedBox(),
               ),
             ),
-          ),
-          Positioned(
-            bottom: 12,
-            right: 12,
-            child: // 加载更多按钮
-                Visibility(
-              visible: (Platform.isWindows ||
-                      Platform.isLinux ||
-                      Platform.isMacOS) &&
-                  pageController.canLoadMore.value &&
-                  !pageController.pageLoadding.value &&
-                  !pageController.pageEmpty.value &&
-                  showPCRefreshButton,
-              child: Center(
-                child: IconButton(
-                  style: IconButton.styleFrom(
-                    backgroundColor: Get.theme.cardColor.withAlpha(200),
-                    elevation: 4,
+            Positioned(
+              bottom: 8,
+              left: 0,
+              right: 0,
+              child: Visibility(
+                visible: showDesktopActions,
+                child: Center(
+                  child: FilledButton.tonal(
+                    style: FilledButton.styleFrom(
+                      minimumSize: const Size(0, 44),
+                    ),
+                    onPressed: pageController.loadData,
+                    child: const Text('加载更多'),
                   ),
-                  onPressed: () {
-                    pageController.refreshData();
-                  },
-                  icon: const Icon(Icons.refresh),
                 ),
               ),
             ),
-          ),
-          Offstage(
-            offstage: !pageController.pageEmpty.value,
-            child: AppEmptyWidget(
-              onRefresh: () => pageController.refreshData(),
+            Positioned(
+              bottom: 12,
+              right: 12,
+              child: Visibility(
+                visible: showDesktopActions && showPCRefreshButton,
+                child: DesktopRefreshButton(
+                  refreshing: false,
+                  onPressed: pageController.refreshData,
+                ),
+              ),
             ),
-          ),
-          Offstage(
-            offstage: !(showPageLoadding && pageController.pageLoadding.value),
-            child: const AppLoaddingWidget(),
-          ),
-          Offstage(
-            offstage: !pageController.pageError.value,
-            child: AppErrorWidget(
-              errorMsg: pageController.errorMsg.value,
-              onRefresh: () => pageController.refreshData(),
+            Offstage(
+              offstage: !pageController.pageEmpty.value,
+              child: AppEmptyWidget(
+                onRefresh: pageController.refreshData,
+              ),
             ),
-          ),
-        ],
-      ),
+            Offstage(
+              offstage:
+                  !(showPageLoadding && pageController.pageLoadding.value),
+              child: const AppLoaddingWidget(),
+            ),
+            Offstage(
+              offstage: !pageController.pageError.value,
+              child: AppErrorWidget(
+                errorMsg: pageController.errorMsg.value,
+                onRefresh: pageController.refreshData,
+              ),
+            ),
+          ],
+        );
+      },
     );
   }
 }

--- a/simple_live_app/lib/widgets/settings/settings_action.dart
+++ b/simple_live_app/lib/widgets/settings/settings_action.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:get/get.dart';
-import 'package:simple_live_app/app/app_style.dart';
+import 'package:simple_live_app/widgets/settings/settings_tile.dart';
 
 class SettingsAction extends StatelessWidget {
   final String title;
@@ -20,41 +19,11 @@ class SettingsAction extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return ListTile(
-      // visualDensity: VisualDensity.compact,
+    return SettingsTile(
+      title: title,
+      subtitle: subtitle,
       leading: leading,
-      title: Text(
-        title,
-        style: Theme.of(context).textTheme.bodyLarge,
-      ),
-      shape: RoundedRectangleBorder(
-        borderRadius: AppStyle.radius8,
-      ),
-      contentPadding: AppStyle.edgeInsetsL16.copyWith(right: 8),
-      subtitle: subtitle == null
-          ? null
-          : Text(
-              subtitle!,
-              style: Get.textTheme.bodySmall!.copyWith(color: Colors.grey),
-            ),
-      trailing: Row(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          if (value != null)
-            Text(
-              value!,
-              style: Theme.of(context)
-                  .textTheme
-                  .bodyMedium!
-                  .copyWith(color: Colors.grey),
-            ),
-          AppStyle.hGap4,
-          const Icon(
-            Icons.chevron_right,
-            color: Colors.grey,
-          ),
-        ],
-      ),
+      trailing: SettingsValueIndicator(value: value),
       onTap: onTap,
     );
   }

--- a/simple_live_app/lib/widgets/settings/settings_card.dart
+++ b/simple_live_app/lib/widgets/settings/settings_card.dart
@@ -1,28 +1,25 @@
 import 'package:flutter/material.dart';
-import 'package:simple_live_app/app/app_style.dart';
+import 'package:simple_live_app/app/design_system/app_design_tokens.dart';
+import 'package:simple_live_app/app/design_system/app_theme_extension.dart';
 
 class SettingsCard extends StatelessWidget {
   final Widget child;
+
   const SettingsCard({required this.child, super.key});
 
   @override
   Widget build(BuildContext context) {
+    final semantic = context.appTheme;
+
     return Material(
-      color: Theme.of(context).brightness == Brightness.dark
-          ? Colors.grey.withAlpha(50)
-          : Colors.white70,
+      color: semantic.secondarySurface,
+      surfaceTintColor: Colors.transparent,
+      clipBehavior: Clip.antiAlias,
       shape: RoundedRectangleBorder(
-        borderRadius: AppStyle.radius8,
-        side: BorderSide(
-          color: Colors.grey.withAlpha(25),
-        ),
+        borderRadius: BorderRadius.circular(AppDesignTokens.radius16),
+        side: BorderSide(color: semantic.border),
       ),
-      child: Container(
-        decoration: BoxDecoration(
-          borderRadius: AppStyle.radius8,
-        ),
-        child: child,
-      ),
+      child: child,
     );
   }
 }

--- a/simple_live_app/lib/widgets/settings/settings_menu.dart
+++ b/simple_live_app/lib/widgets/settings/settings_menu.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
-import 'package:simple_live_app/app/app_style.dart';
+import 'package:simple_live_app/widgets/settings/settings_tile.dart';
 
 class SettingsMenu<T> extends StatelessWidget {
   final String title;
@@ -8,8 +8,8 @@ class SettingsMenu<T> extends StatelessWidget {
   final Map<T, String> valueMap;
   final T value;
   final Widget? trailing;
-
   final Function(T)? onChanged;
+
   const SettingsMenu({
     required this.title,
     required this.value,
@@ -22,39 +22,10 @@ class SettingsMenu<T> extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return ListTile(
-      visualDensity: VisualDensity.compact,
-      title: Text(
-        title,
-        style: Theme.of(context).textTheme.bodyLarge,
-      ),
-      shape: RoundedRectangleBorder(
-        borderRadius: AppStyle.radius8,
-      ),
-      contentPadding: AppStyle.edgeInsetsL16.copyWith(right: 8),
-      subtitle: subtitle == null
-          ? null
-          : Text(
-              subtitle!,
-              style: Get.textTheme.bodySmall!.copyWith(color: Colors.grey),
-            ),
-      trailing: trailing ?? Row(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          Text(
-            valueMap[value]!.tr,
-            style: Theme.of(context)
-                .textTheme
-                .bodyMedium!
-                .copyWith(color: Colors.grey),
-          ),
-          AppStyle.hGap4,
-          const Icon(
-            Icons.chevron_right,
-            color: Colors.grey,
-          ),
-        ],
-      ),
+    return SettingsTile(
+      title: title,
+      subtitle: subtitle,
+      trailing: trailing ?? SettingsValueIndicator(value: valueMap[value]!.tr),
       onTap: () => openMenu(context),
     );
   }
@@ -63,26 +34,24 @@ class SettingsMenu<T> extends StatelessWidget {
     showModalBottomSheet(
       context: context,
       showDragHandle: true,
-      useSafeArea: true, //useSafeArea似乎无效
+      useSafeArea: true,
       builder: (_) => SafeArea(
         top: false,
         child: SingleChildScrollView(
+          padding: const EdgeInsets.only(bottom: 8),
           child: RadioGroup(
             groupValue: value,
-            onChanged: (e) {
+            onChanged: (selectedValue) {
               Get.back();
-              onChanged?.call(e as T);
+              onChanged?.call(selectedValue as T);
             },
             child: Column(
               mainAxisSize: MainAxisSize.min,
               children: valueMap.keys
                   .map(
-                    (e) => RadioListTile(
-                      value: e,
-                      title: Text(
-                        (valueMap[e]?.tr) ?? "???",
-                        style: Get.textTheme.bodyMedium,
-                      ),
+                    (menuValue) => RadioListTile(
+                      value: menuValue,
+                      title: Text((valueMap[menuValue]?.tr) ?? '???'),
                     ),
                   )
                   .toList(),

--- a/simple_live_app/lib/widgets/settings/settings_menu_check.dart
+++ b/simple_live_app/lib/widgets/settings/settings_menu_check.dart
@@ -2,7 +2,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter_smart_dialog/flutter_smart_dialog.dart';
 import 'package:get/get.dart';
 import 'package:remixicon/remixicon.dart';
-import 'package:simple_live_app/app/app_style.dart';
+import 'package:simple_live_app/app/design_system/app_design_tokens.dart';
+import 'package:simple_live_app/widgets/settings/settings_tile.dart';
 
 class _MenuCheckController<T> extends GetxController {
   final RxList<T> selectedItems;
@@ -26,7 +27,6 @@ class SettingsMenuCheck<T> extends StatelessWidget {
   final List<T> initialSelection;
   final Future<List<T>> Function()? itemsProvider;
   final List<T> Function(List<T> providedItems)? initialSelectionProvider;
-
   final String Function(T item) itemToString;
   final Function(List<T> selectedItems)? onConfirm;
   final String? confirmText;
@@ -48,52 +48,24 @@ class SettingsMenuCheck<T> extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    // 这里需要状态管理，暂时不实现
     final displayItemsCount = items.length;
     final displaySelectedCount = initialSelection.length;
 
-    return ListTile(
-      visualDensity: VisualDensity.compact,
-      title: Text(
-        title,
-        style: Theme.of(context).textTheme.bodyLarge,
+    return SettingsTile(
+      title: title,
+      subtitle: subtitle,
+      trailing: SettingsValueIndicator(
+        value: '$displaySelectedCount/$displayItemsCount',
       ),
-      shape: RoundedRectangleBorder(
-        borderRadius: AppStyle.radius8,
-      ),
-      contentPadding: AppStyle.edgeInsetsL16.copyWith(right: 8),
-      subtitle: subtitle == null
-          ? null
-          : Text(
-              subtitle!,
-              style: Get.textTheme.bodySmall!.copyWith(color: Colors.grey),
-            ),
-      trailing: Row(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          Text(
-            '$displaySelectedCount/$displayItemsCount',
-            style: Theme.of(context)
-                .textTheme
-                .bodyMedium!
-                .copyWith(color: Colors.grey),
-          ),
-          AppStyle.hGap4,
-          const Icon(
-            Icons.chevron_right,
-            color: Colors.grey,
-          ),
-        ],
-      ),
-      onTap: _handleTap,
+      onTap: () => _handleTap(context),
     );
   }
 
-  Future<void> _handleTap() async {
+  Future<void> _handleTap(BuildContext context) async {
     List<T> menuItems;
     List<T> menuInitialSelection;
     if (itemsProvider != null) {
-      SmartDialog.showLoading(msg: "");
+      SmartDialog.showLoading(msg: '');
       try {
         menuItems = await itemsProvider!();
         if (initialSelectionProvider != null) {
@@ -109,15 +81,18 @@ class SettingsMenuCheck<T> extends StatelessWidget {
       menuInitialSelection = initialSelection;
     }
 
-    if (menuItems.isEmpty) {
+    if (menuItems.isEmpty || !context.mounted) {
       return;
     }
 
-    _openMenu(Get.context!, menuItems, menuInitialSelection);
+    _openMenu(context, menuItems, menuInitialSelection);
   }
 
   void _openMenu(
-      BuildContext context, List<T> items, List<T> initialSelection) {
+    BuildContext context,
+    List<T> items,
+    List<T> initialSelection,
+  ) {
     final controller = _MenuCheckController<T>(initialSelection);
 
     showModalBottomSheet(
@@ -125,13 +100,11 @@ class SettingsMenuCheck<T> extends StatelessWidget {
       isScrollControlled: true,
       showDragHandle: false,
       useSafeArea: true,
-      constraints: BoxConstraints(
-        maxWidth: 600,
-      ),
+      constraints: const BoxConstraints(maxWidth: 600),
       shape: const RoundedRectangleBorder(
         borderRadius: BorderRadius.only(
-          topLeft: Radius.circular(12),
-          topRight: Radius.circular(12),
+          topLeft: Radius.circular(AppDesignTokens.radius16),
+          topRight: Radius.circular(AppDesignTokens.radius16),
         ),
       ),
       builder: (_) {
@@ -141,13 +114,17 @@ class SettingsMenuCheck<T> extends StatelessWidget {
             mainAxisSize: MainAxisSize.min,
             children: [
               ListTile(
-                contentPadding: const EdgeInsets.only(
-                  left: 12,
-                ),
+                contentPadding: const EdgeInsets.only(left: 16, right: 8),
                 title: Text(
                   modalTitle?.tr ?? title.tr,
+                  style: Theme.of(context).textTheme.titleMedium,
                 ),
                 trailing: IconButton(
+                  constraints: const BoxConstraints(
+                    minWidth: 44,
+                    minHeight: 44,
+                  ),
+                  tooltip: confirmText?.tr ?? '确定',
                   onPressed: () {
                     Get.back();
                     onConfirm?.call(controller.selectedItems.toList());
@@ -155,22 +132,23 @@ class SettingsMenuCheck<T> extends StatelessWidget {
                   icon: const Icon(Remix.delete_bin_line),
                 ),
               ),
+              const Divider(),
               Flexible(
                 child: SingleChildScrollView(
+                  padding: const EdgeInsets.only(bottom: 8),
                   child: Column(
                     mainAxisSize: MainAxisSize.min,
                     children: items.map((item) {
-                      return Obx(() => CheckboxListTile(
-                            value: controller.selectedItems.contains(item),
-                            controlAffinity: ListTileControlAffinity.leading,
-                            title: Text(
-                              itemToString(item),
-                              style: Get.textTheme.bodyMedium,
-                            ),
-                            onChanged: (bool? selected) {
-                              controller.toggle(item);
-                            },
-                          ));
+                      return Obx(
+                        () => CheckboxListTile(
+                          value: controller.selectedItems.contains(item),
+                          controlAffinity: ListTileControlAffinity.leading,
+                          title: Text(itemToString(item)),
+                          onChanged: (selected) {
+                            controller.toggle(item);
+                          },
+                        ),
+                      );
                     }).toList(),
                   ),
                 ),

--- a/simple_live_app/lib/widgets/settings/settings_number.dart
+++ b/simple_live_app/lib/widgets/settings/settings_number.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
-import 'package:simple_live_app/app/app_style.dart';
+import 'package:simple_live_app/app/design_system/app_design_tokens.dart';
+import 'package:simple_live_app/app/design_system/app_theme_extension.dart';
+import 'package:simple_live_app/widgets/settings/settings_tile.dart';
 
 class SettingsNumber extends StatelessWidget {
   final String title;
@@ -12,85 +14,88 @@ class SettingsNumber extends StatelessWidget {
   final int max;
   final String? displayValue;
   final Function(int)? onChanged;
-  const SettingsNumber(
-      {required this.title,
-      required this.value,
-      required this.max,
-      this.subtitle,
-      this.onChanged,
-      this.step = 1,
-      this.min = 0,
-      this.unit = '',
-      this.displayValue,
-      super.key});
+
+  const SettingsNumber({
+    required this.title,
+    required this.value,
+    required this.max,
+    this.subtitle,
+    this.onChanged,
+    this.step = 1,
+    this.min = 0,
+    this.unit = '',
+    this.displayValue,
+    super.key,
+  });
 
   @override
   Widget build(BuildContext context) {
-    return ListTile(
-      visualDensity: VisualDensity.compact,
-      title: Text(
-        title,
-        style: Get.textTheme.bodyLarge,
-      ),
-      shape: RoundedRectangleBorder(
-        borderRadius: AppStyle.radius8,
-      ),
-      subtitle: subtitle == null
-          ? null
-          : Text(
-              subtitle!,
-              style: Get.textTheme.bodySmall!.copyWith(color: Colors.grey),
-            ),
-      contentPadding: AppStyle.edgeInsetsL16.copyWith(right: 12),
+    final semantic = context.appTheme;
+    final theme = Theme.of(context);
+
+    return SettingsTile(
+      title: title,
+      subtitle: subtitle,
       trailing: Container(
+        height: 44,
         decoration: BoxDecoration(
-          color: Colors.grey.withAlpha(25),
-          borderRadius: AppStyle.radius24,
+          color: semantic.elevatedSurface,
+          borderRadius: BorderRadius.circular(AppDesignTokens.radius12),
+          border: Border.all(color: semantic.border),
         ),
-        height: 36,
         child: Row(
           mainAxisSize: MainAxisSize.min,
           children: [
             IconButton(
-              padding: AppStyle.edgeInsetsA4,
               constraints: const BoxConstraints(
-                minHeight: 32,
+                minWidth: 44,
+                minHeight: 44,
               ),
+              padding: EdgeInsets.zero,
+              tooltip: '减少',
               onPressed: () {
-                int newValue = value - step;
+                var newValue = value - step;
                 if (newValue < min) {
                   newValue = min;
                 }
                 onChanged?.call(newValue);
               },
               icon: Icon(
-                Icons.remove,
-                color: Get.textTheme.bodyMedium!.color!.withAlpha(150),
+                Icons.remove_rounded,
+                size: 18,
+                color: semantic.textSecondary,
               ),
             ),
-            Text(
-              displayValue ?? "$value$unit",
-              textAlign: TextAlign.center,
-              style: Theme.of(context)
-                  .textTheme
-                  .bodyMedium!
-                  .copyWith(color: Colors.grey),
+            ConstrainedBox(
+              constraints: const BoxConstraints(minWidth: 44, maxWidth: 88),
+              child: Text(
+                displayValue ?? '$value$unit',
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+                textAlign: TextAlign.center,
+                style: theme.textTheme.labelLarge?.copyWith(
+                  color: semantic.textPrimary,
+                ),
+              ),
             ),
             IconButton(
-              padding: AppStyle.edgeInsetsA4,
               constraints: const BoxConstraints(
-                minHeight: 32,
+                minWidth: 44,
+                minHeight: 44,
               ),
+              padding: EdgeInsets.zero,
+              tooltip: '增加',
               onPressed: () {
-                int newValue = value + step;
+                var newValue = value + step;
                 if (newValue > max) {
                   newValue = max;
                 }
                 onChanged?.call(newValue);
               },
               icon: Icon(
-                Icons.add,
-                color: Get.textTheme.bodyMedium!.color!.withAlpha(150),
+                Icons.add_rounded,
+                size: 18,
+                color: semantic.textSecondary,
               ),
             ),
           ],
@@ -101,56 +106,52 @@ class SettingsNumber extends StatelessWidget {
   }
 
   void openSilder(BuildContext context) {
-    var newValue = value.obs;
+    final newValue = value.obs;
     showModalBottomSheet(
       context: context,
       showDragHandle: true,
-      useSafeArea: true, //useSafeArea似乎无效
+      useSafeArea: true,
       builder: (_) => SafeArea(
         top: false,
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          crossAxisAlignment: CrossAxisAlignment.stretch,
-          children: [
-            Padding(
-              padding: AppStyle.edgeInsetsH16,
-              child: Row(
+        child: Padding(
+          padding: const EdgeInsets.fromLTRB(16, 0, 16, 16),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              Row(
                 mainAxisAlignment: MainAxisAlignment.spaceBetween,
                 children: [
-                  Text(
-                    title,
-                    style: Get.textTheme.titleMedium,
-                  ),
+                  Text(title, style: Theme.of(context).textTheme.titleMedium),
                   Obx(
                     () => Text(
-                      "${newValue.value}$unit",
-                      style: Get.textTheme.titleMedium,
+                      '${newValue.value}$unit',
+                      style: Theme.of(context).textTheme.titleMedium,
                     ),
                   ),
                 ],
               ),
-            ),
-            Obx(
-              () => Slider(
-                value: newValue.value.toDouble(),
-                min: min.toDouble(),
-                max: max.toDouble(),
-                onChanged: (e) {
-                  newValue.value = e.toInt();
-                },
+              const SizedBox(height: 8),
+              Obx(
+                () => Slider(
+                  value: newValue.value.toDouble(),
+                  min: min.toDouble(),
+                  max: max.toDouble(),
+                  onChanged: (sliderValue) {
+                    newValue.value = sliderValue.toInt();
+                  },
+                ),
               ),
-            ),
-            Padding(
-              padding: AppStyle.edgeInsetsH16,
-              child: TextButton(
+              const SizedBox(height: 8),
+              FilledButton(
                 onPressed: () {
                   onChanged?.call(newValue.value);
                   Get.back();
                 },
-                child: const Text("确定"),
+                child: const Text('确定'),
               ),
-            ),
-          ],
+            ],
+          ),
         ),
       ),
     );

--- a/simple_live_app/lib/widgets/settings/settings_switch.dart
+++ b/simple_live_app/lib/widgets/settings/settings_switch.dart
@@ -1,11 +1,13 @@
 import 'package:flutter/material.dart';
-import 'package:simple_live_app/app/app_style.dart';
+import 'package:simple_live_app/app/design_system/app_design_tokens.dart';
+import 'package:simple_live_app/app/design_system/app_theme_extension.dart';
 
 class SettingsSwitch extends StatelessWidget {
   final bool value;
   final String title;
   final String? subtitle;
   final Function(bool) onChanged;
+
   const SettingsSwitch({
     required this.value,
     required this.title,
@@ -16,26 +18,33 @@ class SettingsSwitch extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final semantic = context.appTheme;
+    final theme = Theme.of(context);
+
     return SwitchListTile(
+      visualDensity: VisualDensity.compact,
       title: Text(
         title,
-        style: Theme.of(context).textTheme.bodyLarge,
+        style: theme.textTheme.titleSmall?.copyWith(
+          color: semantic.textPrimary,
+          fontWeight: FontWeight.w600,
+        ),
       ),
+      subtitle: subtitle == null
+          ? null
+          : Padding(
+              padding: const EdgeInsets.only(top: 2),
+              child: Text(
+                subtitle!,
+                style: theme.textTheme.bodySmall?.copyWith(
+                  color: semantic.textSecondary,
+                ),
+              ),
+            ),
       shape: RoundedRectangleBorder(
-        borderRadius: AppStyle.radius8,
+        borderRadius: BorderRadius.circular(AppDesignTokens.radius12),
       ),
-      trackOutlineColor: const WidgetStatePropertyAll(Colors.transparent),
-      //visualDensity: VisualDensity.compact,
-      contentPadding: AppStyle.edgeInsetsL16.copyWith(right: 8),
-      subtitle: subtitle != null
-          ? Text(
-              subtitle!,
-              style: Theme.of(context)
-                  .textTheme
-                  .bodySmall!
-                  .copyWith(color: Colors.grey),
-            )
-          : null,
+      contentPadding: const EdgeInsets.only(left: 16, right: 8),
       value: value,
       onChanged: onChanged,
     );

--- a/simple_live_app/lib/widgets/settings/settings_tile.dart
+++ b/simple_live_app/lib/widgets/settings/settings_tile.dart
@@ -1,0 +1,97 @@
+import 'package:flutter/material.dart';
+import 'package:simple_live_app/app/design_system/app_design_tokens.dart';
+import 'package:simple_live_app/app/design_system/app_theme_extension.dart';
+
+class SettingsTile extends StatelessWidget {
+  const SettingsTile({
+    required this.title,
+    this.subtitle,
+    this.leading,
+    this.trailing,
+    this.onTap,
+    super.key,
+  });
+
+  final String title;
+  final String? subtitle;
+  final Widget? leading;
+  final Widget? trailing;
+  final Function()? onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final semantic = context.appTheme;
+    final theme = Theme.of(context);
+
+    return ListTile(
+      visualDensity: VisualDensity.compact,
+      minVerticalPadding: 10,
+      leading: leading,
+      title: Text(
+        title,
+        style: theme.textTheme.titleSmall?.copyWith(
+          color: semantic.textPrimary,
+          fontWeight: FontWeight.w600,
+        ),
+      ),
+      subtitle: subtitle == null
+          ? null
+          : Padding(
+              padding: const EdgeInsets.only(top: 2),
+              child: Text(
+                subtitle!,
+                style: theme.textTheme.bodySmall?.copyWith(
+                  color: semantic.textSecondary,
+                ),
+              ),
+            ),
+      trailing: trailing,
+      contentPadding: const EdgeInsets.only(left: 16, right: 12),
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(AppDesignTokens.radius12),
+      ),
+      onTap: onTap,
+    );
+  }
+}
+
+class SettingsValueIndicator extends StatelessWidget {
+  const SettingsValueIndicator({
+    this.value,
+    this.showChevron = true,
+    super.key,
+  });
+
+  final String? value;
+  final bool showChevron;
+
+  @override
+  Widget build(BuildContext context) {
+    final semantic = context.appTheme;
+    final theme = Theme.of(context);
+
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        if (value != null)
+          ConstrainedBox(
+            constraints: const BoxConstraints(maxWidth: 180),
+            child: Text(
+              value!,
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+              style: theme.textTheme.bodyMedium?.copyWith(
+                color: semantic.textSecondary,
+              ),
+            ),
+          ),
+        if (value != null && showChevron) const SizedBox(width: 4),
+        if (showChevron)
+          Icon(
+            Icons.chevron_right_rounded,
+            color: semantic.textTertiary,
+          ),
+      ],
+    );
+  }
+}

--- a/simple_live_app/lib/widgets/shadow_card.dart
+++ b/simple_live_app/lib/widgets/shadow_card.dart
@@ -1,49 +1,110 @@
 import 'package:flutter/material.dart';
-import 'package:get/get.dart';
-import 'package:simple_live_app/app/app_style.dart';
+import 'package:simple_live_app/app/design_system/app_design_tokens.dart';
+import 'package:simple_live_app/app/design_system/app_theme_extension.dart';
 
-class ShadowCard extends StatelessWidget {
+class ShadowCard extends StatefulWidget {
   final Widget child;
   final double radius;
   final Function()? onTap;
   final Function()? onLongPress;
+
   const ShadowCard({
     required this.child,
-    this.radius = 8.0,
+    this.radius = AppDesignTokens.radius12,
     this.onTap,
     this.onLongPress,
     super.key,
   });
 
   @override
+  State<ShadowCard> createState() => _ShadowCardState();
+}
+
+class _ShadowCardState extends State<ShadowCard> {
+  bool _hovered = false;
+  bool _focused = false;
+  bool _pressed = false;
+
+  bool get _interactive =>
+      widget.onTap != null || widget.onLongPress != null;
+
+  void _setHovered(bool value) {
+    if (_hovered == value) return;
+    setState(() => _hovered = value);
+  }
+
+  void _setFocused(bool value) {
+    if (_focused == value) return;
+    setState(() => _focused = value);
+  }
+
+  void _setPressed(bool value) {
+    if (_pressed == value) return;
+    setState(() => _pressed = value);
+  }
+
+  @override
   Widget build(BuildContext context) {
-    return Container(
+    final semantic = context.appTheme;
+    final colorScheme = Theme.of(context).colorScheme;
+    final reduceMotion = MediaQuery.of(context).disableAnimations;
+    final duration = reduceMotion
+        ? Duration.zero
+        : const Duration(milliseconds: 140);
+    final emphasized = _interactive && (_hovered || _focused);
+    final borderColor = emphasized
+        ? colorScheme.primary.withAlpha(90)
+        : semantic.border;
+    final shadowAlphaFactor =
+        _pressed ? 0.35 : (emphasized ? 0.9 : 0.65);
+
+    Widget surface = AnimatedContainer(
+      duration: duration,
+      curve: Curves.easeOutCubic,
       decoration: BoxDecoration(
-        borderRadius: BorderRadius.circular(radius),
-        boxShadow: Get.isDarkMode
-            ? []
-            : [
-                BoxShadow(
-                  blurRadius: 4,
-                  color: Colors.grey.withAlpha(50),
-                )
-              ],
+        color: semantic.elevatedSurface,
+        borderRadius: BorderRadius.circular(widget.radius),
+        border: Border.all(color: borderColor),
+        boxShadow: [
+          BoxShadow(
+            color: semantic.shadow.withValues(
+              alpha: semantic.shadow.a * shadowAlphaFactor,
+            ),
+            blurRadius: emphasized ? 12 : 8,
+            offset: Offset(0, emphasized ? 4 : 2),
+          ),
+        ],
       ),
       child: Material(
-        color: Theme.of(context).cardColor,
-        borderRadius: BorderRadius.circular(radius),
-        child: InkWell(
-          borderRadius: BorderRadius.circular(radius),
-          onLongPress: onLongPress,
-          onTap: onTap,
-          child: Container(
-            decoration: BoxDecoration(
-              borderRadius: AppStyle.radius8,
-            ),
-            child: child,
-          ),
-        ),
+        color: Colors.transparent,
+        clipBehavior: Clip.antiAlias,
+        borderRadius: BorderRadius.circular(widget.radius),
+        child: _interactive
+            ? InkWell(
+                borderRadius: BorderRadius.circular(widget.radius),
+                onTap: widget.onTap,
+                onLongPress: widget.onLongPress,
+                onHover: _setHovered,
+                onFocusChange: _setFocused,
+                onHighlightChanged: _setPressed,
+                focusColor: colorScheme.primary.withAlpha(18),
+                hoverColor: colorScheme.primary.withAlpha(12),
+                highlightColor: colorScheme.primary.withAlpha(16),
+                child: widget.child,
+              )
+            : widget.child,
       ),
+    );
+
+    if (!_interactive || reduceMotion) {
+      return surface;
+    }
+
+    return AnimatedScale(
+      duration: duration,
+      curve: Curves.easeOutCubic,
+      scale: _pressed ? 0.99 : (emphasized ? 1.006 : 1),
+      child: surface,
     );
   }
 }

--- a/simple_live_app/lib/widgets/status/app_empty_widget.dart
+++ b/simple_live_app/lib/widgets/status/app_empty_widget.dart
@@ -1,38 +1,29 @@
 import 'package:flutter/material.dart';
-import 'package:simple_live_app/app/app_style.dart';
 import 'package:lottie/lottie.dart';
+import 'package:simple_live_app/widgets/status/app_status_panel.dart';
 
 class AppEmptyWidget extends StatelessWidget {
   final Function()? onRefresh;
+
   const AppEmptyWidget({this.onRefresh, super.key});
 
   @override
   Widget build(BuildContext context) {
-    return Center(
-      child: GestureDetector(
-        onTap: () {
-          onRefresh?.call();
-        },
-        child: Padding(
-          padding: AppStyle.edgeInsetsA12,
-          child: Column(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              LottieBuilder.asset(
-                'assets/lotties/empty.json',
-                width: 200,
-                height: 200,
-                repeat: false,
-              ),
-              const Text(
-                "这里什么都没有",
-                textAlign: TextAlign.center,
-                style: TextStyle(fontSize: 12, color: Colors.grey),
-              ),
-            ],
-          ),
+    return AppStatusPanel(
+      visual: ExcludeSemantics(
+        child: LottieBuilder.asset(
+          'assets/lotties/empty.json',
+          width: 144,
+          height: 112,
+          fit: BoxFit.contain,
+          repeat: false,
+          animate: !MediaQuery.of(context).disableAnimations,
         ),
       ),
+      title: '这里什么都没有',
+      message: onRefresh == null ? null : '可以刷新后再试一次',
+      actionLabel: onRefresh == null ? null : '刷新',
+      onRefresh: onRefresh,
     );
   }
 }

--- a/simple_live_app/lib/widgets/status/app_error_widget.dart
+++ b/simple_live_app/lib/widgets/status/app_error_widget.dart
@@ -1,38 +1,34 @@
 import 'package:flutter/material.dart';
-import 'package:simple_live_app/app/app_style.dart';
 import 'package:lottie/lottie.dart';
+import 'package:simple_live_app/widgets/status/app_status_panel.dart';
 
 class AppErrorWidget extends StatelessWidget {
   final Function()? onRefresh;
   final String errorMsg;
-  const AppErrorWidget({this.errorMsg = "", this.onRefresh, super.key});
+
+  const AppErrorWidget({
+    this.errorMsg = '',
+    this.onRefresh,
+    super.key,
+  });
 
   @override
   Widget build(BuildContext context) {
-    return Center(
-      child: GestureDetector(
-        onTap: () {
-          onRefresh?.call();
-        },
-        child: Padding(
-          padding: AppStyle.edgeInsetsA12,
-          child: Column(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              LottieBuilder.asset(
-                'assets/lotties/error.json',
-                width: 260,
-                repeat: false,
-              ),
-              Text(
-                "$errorMsg\r\n点击刷新",
-                textAlign: TextAlign.center,
-                style: const TextStyle(fontSize: 12, color: Colors.grey),
-              ),
-            ],
-          ),
+    return AppStatusPanel(
+      visual: ExcludeSemantics(
+        child: LottieBuilder.asset(
+          'assets/lotties/error.json',
+          width: 156,
+          height: 112,
+          fit: BoxFit.contain,
+          repeat: false,
+          animate: !MediaQuery.of(context).disableAnimations,
         ),
       ),
+      title: '加载失败',
+      message: errorMsg.isEmpty ? '请稍后再试' : errorMsg,
+      actionLabel: onRefresh == null ? null : '重新加载',
+      onRefresh: onRefresh,
     );
   }
 }

--- a/simple_live_app/lib/widgets/status/app_loadding_widget.dart
+++ b/simple_live_app/lib/widgets/status/app_loadding_widget.dart
@@ -1,30 +1,54 @@
-import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
-import 'package:get/get.dart';
-import 'package:simple_live_app/app/app_style.dart';
+import 'package:simple_live_app/app/design_system/app_design_tokens.dart';
+import 'package:simple_live_app/app/design_system/app_theme_extension.dart';
 
 class AppLoaddingWidget extends StatelessWidget {
   const AppLoaddingWidget({super.key});
 
   @override
   Widget build(BuildContext context) {
+    final semantic = context.appTheme;
+    final theme = Theme.of(context);
+
     return Center(
-      child: Container(
-        padding: AppStyle.edgeInsetsA12,
-        decoration: BoxDecoration(
-          shape: BoxShape.circle,
-          color: Theme.of(context).cardColor,
-          boxShadow: Get.isDarkMode
-              ? []
-              : [
-                  BoxShadow(
-                    blurRadius: 4,
-                    color: Colors.grey.withAlpha(50),
-                  )
-                ],
-        ),
-        child: const CupertinoActivityIndicator(
-          radius: 10,
+      child: Semantics(
+        container: true,
+        label: '正在加载',
+        child: DecoratedBox(
+          decoration: BoxDecoration(
+            color: semantic.elevatedSurface,
+            borderRadius: BorderRadius.circular(AppDesignTokens.radius16),
+            border: Border.all(color: semantic.border),
+            boxShadow: [
+              BoxShadow(
+                blurRadius: 12,
+                offset: const Offset(0, 4),
+                color: semantic.shadow,
+              ),
+            ],
+          ),
+          child: Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 18, vertical: 14),
+            child: Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                SizedBox.square(
+                  dimension: 20,
+                  child: CircularProgressIndicator(
+                    strokeWidth: 2,
+                    color: theme.colorScheme.primary,
+                  ),
+                ),
+                const SizedBox(width: 10),
+                Text(
+                  '正在加载',
+                  style: theme.textTheme.labelLarge?.copyWith(
+                    color: semantic.textSecondary,
+                  ),
+                ),
+              ],
+            ),
+          ),
         ),
       ),
     );

--- a/simple_live_app/lib/widgets/status/app_status_panel.dart
+++ b/simple_live_app/lib/widgets/status/app_status_panel.dart
@@ -1,0 +1,122 @@
+import 'package:flutter/material.dart';
+import 'package:simple_live_app/app/design_system/app_design_tokens.dart';
+import 'package:simple_live_app/app/design_system/app_theme_extension.dart';
+
+class AppStatusPanel extends StatelessWidget {
+  const AppStatusPanel({
+    required this.visual,
+    required this.title,
+    this.message,
+    this.actionLabel,
+    this.onRefresh,
+    super.key,
+  });
+
+  final Widget visual;
+  final String title;
+  final String? message;
+  final String? actionLabel;
+  final Function()? onRefresh;
+
+  @override
+  Widget build(BuildContext context) {
+    final semantic = context.appTheme;
+    final theme = Theme.of(context);
+    final radius = BorderRadius.circular(AppDesignTokens.radius16);
+
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final compact =
+            constraints.hasBoundedHeight && constraints.maxHeight < 320;
+        final panel = ConstrainedBox(
+          constraints: const BoxConstraints(maxWidth: 360),
+          child: DecoratedBox(
+            decoration: BoxDecoration(
+              color: semantic.elevatedSurface,
+              borderRadius: radius,
+              border: Border.all(color: semantic.border),
+              boxShadow: [
+                BoxShadow(
+                  color: semantic.shadow,
+                  blurRadius: 12,
+                  offset: const Offset(0, 4),
+                ),
+              ],
+            ),
+            child: Padding(
+              padding: EdgeInsets.all(compact ? 16 : 24),
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  SizedBox(
+                    height: compact ? 72 : 112,
+                    child: FittedBox(
+                      fit: BoxFit.contain,
+                      child: visual,
+                    ),
+                  ),
+                  SizedBox(height: compact ? 8 : 12),
+                  Text(
+                    title,
+                    textAlign: TextAlign.center,
+                    style: theme.textTheme.titleMedium?.copyWith(
+                      color: semantic.textPrimary,
+                      fontWeight: FontWeight.w700,
+                    ),
+                  ),
+                  if (message?.isNotEmpty == true) ...[
+                    const SizedBox(height: 6),
+                    Text(
+                      message!,
+                      maxLines: compact ? 2 : 4,
+                      overflow: TextOverflow.ellipsis,
+                      textAlign: TextAlign.center,
+                      style: theme.textTheme.bodySmall?.copyWith(
+                        color: semantic.textSecondary,
+                      ),
+                    ),
+                  ],
+                  if (onRefresh != null && actionLabel != null) ...[
+                    SizedBox(height: compact ? 10 : 16),
+                    FilledButton.tonalIcon(
+                      style: FilledButton.styleFrom(
+                        minimumSize: const Size(0, 44),
+                      ),
+                      onPressed: onRefresh,
+                      icon: const Icon(Icons.refresh_rounded, size: 18),
+                      label: Text(actionLabel!),
+                    ),
+                  ],
+                ],
+              ),
+            ),
+          ),
+        );
+
+        final interactivePanel = onRefresh == null
+            ? panel
+            : Material(
+                color: Colors.transparent,
+                borderRadius: radius,
+                child: InkWell(
+                  borderRadius: radius,
+                  onTap: onRefresh,
+                  child: panel,
+                ),
+              );
+
+        final minHeight = constraints.hasBoundedHeight &&
+                constraints.maxHeight > 32
+            ? constraints.maxHeight - 32
+            : 0.0;
+        return SingleChildScrollView(
+          padding: const EdgeInsets.all(16),
+          child: ConstrainedBox(
+            constraints: BoxConstraints(minHeight: minHeight),
+            child: Center(child: interactivePanel),
+          ),
+        );
+      },
+    );
+  }
+}

--- a/simple_live_app/lib/widgets/superchat_card.dart
+++ b/simple_live_app/lib/widgets/superchat_card.dart
@@ -1,11 +1,13 @@
 import 'package:flutter/material.dart';
-import 'package:simple_live_app/app/app_style.dart';
+import 'package:simple_live_app/app/design_system/app_design_tokens.dart';
+import 'package:simple_live_app/app/design_system/app_theme_extension.dart';
 import 'package:simple_live_app/app/utils.dart';
 import 'package:simple_live_app/widgets/net_image.dart';
 import 'package:simple_live_core/simple_live_core.dart';
 
 class SuperChatCard extends StatefulWidget {
   final LiveSuperChatMessage message;
+
   const SuperChatCard(
     this.message, {
     super.key,
@@ -16,92 +18,120 @@ class SuperChatCard extends StatefulWidget {
 }
 
 class _SuperChatCardState extends State<SuperChatCard> {
-
-  @override
-  void initState() {
-    super.initState();
-  }
-
   int _remainSeconds() {
     final now = DateTime.now().millisecondsSinceEpoch ~/ 1000;
     final end = widget.message.endTime.millisecondsSinceEpoch ~/ 1000;
-    int remain = (end - now).clamp(0, 7200);
-    return remain;
+    return (end - now).clamp(0, 7200).toInt();
   }
 
   @override
   Widget build(BuildContext context) {
     final remain = _remainSeconds();
-    return ClipRRect(
-      borderRadius: AppStyle.radius8,
-      child: Container(
-        decoration: BoxDecoration(
-          color: Utils.convertHexColor(widget.message.backgroundColor),
-        ),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.stretch,
-          children: [
-            Padding(
-              padding: AppStyle.edgeInsetsA8,
-              child: Row(
-                children: [
-                  NetImage(
-                    widget.message.face,
-                    width: 48,
-                    height: 48,
-                    borderRadius: 36,
+    final semantic = context.appTheme;
+    final theme = Theme.of(context);
+    final headerColor = Utils.convertHexColor(widget.message.backgroundColor);
+    final messageColor =
+        Utils.convertHexColor(widget.message.backgroundBottomColor);
+    final headerForeground =
+        ThemeData.estimateBrightnessForColor(headerColor) == Brightness.dark
+            ? Colors.white
+            : const Color(0xE0000000);
+    final messageForeground =
+        ThemeData.estimateBrightnessForColor(messageColor) == Brightness.dark
+            ? Colors.white
+            : const Color(0xE0000000);
+
+    return Semantics(
+      container: true,
+      label: '醒目留言，${widget.message.userName}，￥${widget.message.price}',
+      child: ClipRRect(
+        borderRadius: BorderRadius.circular(AppDesignTokens.radius12),
+        child: DecoratedBox(
+          decoration: BoxDecoration(
+            border: Border.all(color: semantic.border),
+            borderRadius: BorderRadius.circular(AppDesignTokens.radius12),
+          ),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              ColoredBox(
+                color: headerColor,
+                child: Padding(
+                  padding: const EdgeInsets.all(12),
+                  child: Row(
+                    children: [
+                      NetImage(
+                        widget.message.face,
+                        width: 42,
+                        height: 42,
+                        borderRadius: 21,
+                      ),
+                      const SizedBox(width: 10),
+                      Expanded(
+                        child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          mainAxisAlignment: MainAxisAlignment.center,
+                          children: [
+                            Text(
+                              widget.message.userName,
+                              maxLines: 1,
+                              overflow: TextOverflow.ellipsis,
+                              style: theme.textTheme.titleSmall?.copyWith(
+                                color: headerForeground,
+                                fontWeight: FontWeight.w700,
+                              ),
+                            ),
+                            const SizedBox(height: 2),
+                            Text(
+                              '￥${widget.message.price}',
+                              style: theme.textTheme.labelMedium?.copyWith(
+                                color: headerForeground.withAlpha(190),
+                                fontWeight: FontWeight.w600,
+                              ),
+                            ),
+                          ],
+                        ),
+                      ),
+                      const SizedBox(width: 8),
+                      Row(
+                        mainAxisSize: MainAxisSize.min,
+                        children: [
+                          Icon(
+                            Icons.schedule_outlined,
+                            size: 14,
+                            color: headerForeground.withAlpha(190),
+                          ),
+                          const SizedBox(width: 3),
+                          Text(
+                            '$remain 秒',
+                            style: theme.textTheme.labelSmall?.copyWith(
+                              color: headerForeground.withAlpha(190),
+                              fontWeight: FontWeight.w600,
+                            ),
+                          ),
+                        ],
+                      ),
+                    ],
                   ),
-                  AppStyle.hGap12,
-                  Expanded(
-                    child: Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      mainAxisAlignment: MainAxisAlignment.center,
-                      children: [
-                        Text(
-                          widget.message.userName,
-                          style: const TextStyle(
-                            color: AppColors.black333,
-                          ),
-                        ),
-                        Text(
-                          "￥${widget.message.price}",
-                          style: const TextStyle(
-                            fontSize: 12,
-                            color: Colors.grey,
-                          ),
-                        ),
-                      ],
+                ),
+              ),
+              ColoredBox(
+                color: messageColor,
+                child: Padding(
+                  padding: const EdgeInsets.all(12),
+                  child: SelectableText(
+                    widget.message.message,
+                    style: theme.textTheme.bodyMedium?.copyWith(
+                      color: messageForeground,
+                      fontWeight: FontWeight.w500,
                     ),
                   ),
-                  Text(
-                    "$remain",
-                    style: const TextStyle(
-                      fontSize: 14,
-                      color: Colors.grey,
-                    ),
-                  ),
-                ],
+                ),
               ),
-            ),
-            Container(
-              decoration: BoxDecoration(
-                color:
-                    Utils.convertHexColor(widget.message.backgroundBottomColor),
-              ),
-              padding: AppStyle.edgeInsetsA8,
-              child: SelectableText(
-                widget.message.message,
-                style: const TextStyle(color: Colors.white),
-              ),
-            ),
-          ],
+            ],
+          ),
         ),
       ),
     );
-  }
-
-  @override
-  void dispose() {
-    super.dispose();
   }
 }

--- a/simple_live_app/test/app/app_style_test.dart
+++ b/simple_live_app/test/app/app_style_test.dart
@@ -1,0 +1,71 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:simple_live_app/app/app_style.dart';
+import 'package:simple_live_app/app/design_system/app_design_tokens.dart';
+import 'package:simple_live_app/app/design_system/app_theme_extension.dart';
+
+void main() {
+  group('AppStyle theme construction', () {
+    test('builds the light semantic theme from a resolved color scheme', () {
+      final sourceScheme = ColorScheme.fromSeed(
+        seedColor: AppDesignTokens.defaultSeedColor,
+        brightness: Brightness.light,
+      );
+
+      final theme = AppStyle.light(
+        colorScheme: sourceScheme,
+        fontFamily: 'CustomFont',
+      );
+      final semantic = theme.extension<AppThemeExtension>();
+
+      expect(theme.brightness, Brightness.light);
+      expect(theme.colorScheme.primary, sourceScheme.primary);
+      expect(theme.colorScheme.surface, AppDesignTokens.lightBody);
+      expect(theme.scaffoldBackgroundColor, AppDesignTokens.lightBody);
+      expect(theme.cardColor, AppDesignTokens.lightSecondary);
+      expect(semantic, isNotNull);
+      expect(semantic!.secondarySurface, AppDesignTokens.lightSecondary);
+      expect(semantic.textPrimary, AppDesignTokens.lightTextPrimary);
+      expect(theme.textTheme.bodyMedium?.fontFamily, 'CustomFont');
+      expect(
+        theme.appBarTheme.systemOverlayStyle?.statusBarIconBrightness,
+        Brightness.dark,
+      );
+    });
+
+    test('builds the dark semantic theme from a resolved color scheme', () {
+      final sourceScheme = ColorScheme.fromSeed(
+        seedColor: AppDesignTokens.defaultSeedColor,
+        brightness: Brightness.dark,
+      );
+
+      final theme = AppStyle.darkTheme(colorScheme: sourceScheme);
+      final semantic = theme.extension<AppThemeExtension>();
+
+      expect(theme.brightness, Brightness.dark);
+      expect(theme.colorScheme.primary, sourceScheme.primary);
+      expect(theme.colorScheme.surface, AppDesignTokens.darkBody);
+      expect(theme.scaffoldBackgroundColor, AppDesignTokens.darkBody);
+      expect(theme.cardColor, AppDesignTokens.darkSecondary);
+      expect(semantic, isNotNull);
+      expect(semantic!.secondarySurface, AppDesignTokens.darkSecondary);
+      expect(semantic.textSecondary, AppDesignTokens.darkTextSecondary);
+      expect(
+        theme.appBarTheme.systemOverlayStyle?.statusBarIconBrightness,
+        Brightness.light,
+      );
+    });
+
+    test('keeps semantic extensions interpolatable', () {
+      final light = AppThemeExtension.light();
+      final dark = AppThemeExtension.dark();
+      final midpoint = light.lerp(dark, 0.5);
+
+      expect(midpoint.body, Color.lerp(light.body, dark.body, 0.5));
+      expect(
+        midpoint.textSecondary,
+        Color.lerp(light.textSecondary, dark.textSecondary, 0.5),
+      );
+    });
+  });
+}

--- a/simple_live_app/test/tool_test.dart
+++ b/simple_live_app/test/tool_test.dart
@@ -1,30 +1,23 @@
-﻿import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_test/flutter_test.dart';
 import 'package:pinyin/pinyin.dart';
 
-void testPinyin(){
-  test("测试拼音", (){
-    var str = "zzz你好啊";
-    var res = PinyinHelper.getShortPinyin(str);
-    print(res);
-  });
-}
+void main() {
+  test('converts Chinese text to short pinyin initials', () {
+    final result = PinyinHelper.getShortPinyin('zzz你好啊');
 
-void testDirectoryCheck(String path) {
-  test("测试文件夹路径检测", () {
+    expect(result, startsWith('zzz'));
+    expect(result, contains('n'));
+    expect(result, contains('h'));
+    expect(result, endsWith('a'));
+  });
+
+  test('validates absolute WebDAV-style directory paths', () {
     final regex = RegExp(r'^/([^/]+)(/[^/]+)*$');
-    var res = regex.hasMatch(path);
-    print(res ? "yes" : "no");
-  });
-}
 
-void main(){
-  var p1 = "/123/123";
-  var p2 = "/123/123/123/123";
-  var p3= "123";
-  var p4 = "/123";
-  var p5 = '/123/'; //no
-  var pathList = [p1,p2,p3,p4,p5];
-  for(var path in pathList){
-    testDirectoryCheck(path);
-  }
+    expect(regex.hasMatch('/123/123'), isTrue);
+    expect(regex.hasMatch('/123/123/123/123'), isTrue);
+    expect(regex.hasMatch('/123'), isTrue);
+    expect(regex.hasMatch('123'), isFalse);
+    expect(regex.hasMatch('/123/'), isFalse);
+  });
 }

--- a/simple_live_app/test/widget_test.dart
+++ b/simple_live_app/test/widget_test.dart
@@ -1,30 +1,76 @@
-// This is a basic Flutter widget test.
-//
-// To perform an interaction with a widget in your test, use the WidgetTester
-// utility in the flutter_test package. For example, you can send tap and scroll
-// gestures. You can also use WidgetTester to find child widgets in the widget
-// tree, read text, and verify that the values of widget properties are correct.
-
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-
-import 'package:simple_live_app/main.dart';
+import 'package:simple_live_app/app/app_style.dart';
+import 'package:simple_live_app/app/design_system/app_design_tokens.dart';
 
 void main() {
-  testWidgets('Counter increments smoke test', (WidgetTester tester) async {
-    // Build our app and trigger a frame.
-    await tester.pumpWidget(const MyApp());
+  ThemeData buildTheme(Brightness brightness) {
+    final colorScheme = ColorScheme.fromSeed(
+      seedColor: AppDesignTokens.defaultSeedColor,
+      brightness: brightness,
+    );
+    return brightness == Brightness.dark
+        ? AppStyle.darkTheme(colorScheme: colorScheme)
+        : AppStyle.light(colorScheme: colorScheme);
+  }
 
-    // Verify that our counter starts at 0.
-    expect(find.text('0'), findsOneWidget);
-    expect(find.text('1'), findsNothing);
+  testWidgets('app visual system smoke renders in light and dark themes',
+      (tester) async {
+    for (final brightness in Brightness.values) {
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: buildTheme(brightness),
+          home: Scaffold(
+            appBar: AppBar(title: const Text('Slive')),
+            body: const Center(child: Text('visual smoke')),
+          ),
+        ),
+      );
 
-    // Tap the '+' icon and trigger a frame.
-    await tester.tap(find.byIcon(Icons.add));
+      expect(find.byType(Scaffold), findsOneWidget);
+      expect(find.text('Slive'), findsOneWidget);
+      expect(find.text('visual smoke'), findsOneWidget);
+    }
+  });
+
+  testWidgets('navigation destinations keep touchable labels and icons',
+      (tester) async {
+    var selected = 0;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: buildTheme(Brightness.light),
+        home: StatefulBuilder(
+          builder: (context, setState) {
+            return Scaffold(
+              bottomNavigationBar: NavigationBar(
+                selectedIndex: selected,
+                onDestinationSelected: (value) {
+                  setState(() => selected = value);
+                },
+                destinations: const [
+                  NavigationDestination(
+                    icon: Icon(Icons.home_outlined),
+                    selectedIcon: Icon(Icons.home),
+                    label: '首页',
+                  ),
+                  NavigationDestination(
+                    icon: Icon(Icons.favorite_border),
+                    selectedIcon: Icon(Icons.favorite),
+                    label: '关注',
+                  ),
+                ],
+              ),
+              body: Center(child: Text('selected:$selected')),
+            );
+          },
+        ),
+      ),
+    );
+
+    expect(find.text('selected:0'), findsOneWidget);
+    await tester.tap(find.text('关注'));
     await tester.pump();
-
-    // Verify that our counter has incremented.
-    expect(find.text('0'), findsNothing);
-    expect(find.text('1'), findsOneWidget);
+    expect(find.text('selected:1'), findsOneWidget);
   });
 }

--- a/simple_live_app/test/widgets/shared_primitives_test.dart
+++ b/simple_live_app/test/widgets/shared_primitives_test.dart
@@ -1,0 +1,200 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:simple_live_app/app/app_style.dart';
+import 'package:simple_live_app/app/design_system/app_design_tokens.dart';
+import 'package:simple_live_app/widgets/desktop_refresh_button.dart';
+import 'package:simple_live_app/widgets/filter_button.dart';
+import 'package:simple_live_app/widgets/none_border_circular_textfield.dart';
+import 'package:simple_live_app/widgets/settings/settings_action.dart';
+import 'package:simple_live_app/widgets/settings/settings_switch.dart';
+import 'package:simple_live_app/widgets/shadow_card.dart';
+
+void main() {
+  Widget buildApp(Widget child, {bool disableAnimations = false}) {
+    return MaterialApp(
+      theme: AppStyle.light(
+        colorScheme: ColorScheme.fromSeed(
+          seedColor: AppDesignTokens.defaultSeedColor,
+        ),
+      ),
+      builder: (context, appChild) {
+        return MediaQuery(
+          data: MediaQuery.of(context).copyWith(
+            disableAnimations: disableAnimations,
+          ),
+          child: appChild!,
+        );
+      },
+      home: Scaffold(body: Center(child: child)),
+    );
+  }
+
+  group('shared interaction primitives', () {
+    testWidgets('ShadowCard forwards tap and long press', (tester) async {
+      var taps = 0;
+      var longPresses = 0;
+
+      await tester.pumpWidget(
+        buildApp(
+          ShadowCard(
+            onTap: () => taps++,
+            onLongPress: () => longPresses++,
+            child: const SizedBox(width: 120, height: 72),
+          ),
+        ),
+      );
+
+      await tester.tap(find.byType(ShadowCard));
+      await tester.pump();
+      expect(taps, 1);
+
+      await tester.longPress(find.byType(ShadowCard));
+      await tester.pump();
+      expect(longPresses, 1);
+    });
+
+    testWidgets('ShadowCard avoids interaction wrappers without callbacks',
+        (tester) async {
+      await tester.pumpWidget(
+        buildApp(
+          const ShadowCard(
+            child: SizedBox(width: 120, height: 72),
+          ),
+        ),
+      );
+
+      expect(
+        find.descendant(
+          of: find.byType(ShadowCard),
+          matching: find.byType(InkWell),
+        ),
+        findsNothing,
+      );
+    });
+
+    testWidgets('ShadowCard disables transform motion when requested',
+        (tester) async {
+      await tester.pumpWidget(
+        buildApp(
+          ShadowCard(
+            onTap: () {},
+            child: const SizedBox(width: 120, height: 72),
+          ),
+          disableAnimations: true,
+        ),
+      );
+
+      expect(find.byType(AnimatedScale), findsNothing);
+    });
+
+    testWidgets('FilterButton is tappable and keeps a 44px target',
+        (tester) async {
+      var tapped = false;
+      await tester.pumpWidget(
+        buildApp(
+          FilterButton(
+            selected: true,
+            text: '直播中',
+            onTap: () => tapped = true,
+          ),
+        ),
+      );
+
+      expect(
+        tester.getSize(find.byType(FilterButton)).height,
+        greaterThanOrEqualTo(44),
+      );
+      await tester.tap(find.text('直播中'));
+      expect(tapped, isTrue);
+    });
+
+    testWidgets('DesktopRefreshButton swaps action for progress',
+        (tester) async {
+      var refreshes = 0;
+      await tester.pumpWidget(
+        buildApp(
+          DesktopRefreshButton(
+            refreshing: false,
+            onPressed: () => refreshes++,
+          ),
+        ),
+      );
+
+      await tester.tap(find.byTooltip('刷新'));
+      expect(refreshes, 1);
+
+      await tester.pumpWidget(
+        buildApp(
+          DesktopRefreshButton(
+            refreshing: true,
+            onPressed: () => refreshes++,
+          ),
+        ),
+      );
+
+      expect(find.byType(CircularProgressIndicator), findsOneWidget);
+      expect(find.byTooltip('刷新'), findsNothing);
+    });
+  });
+
+  group('shared form and settings primitives', () {
+    testWidgets('NoneBorderCircularTextField preserves controller callbacks',
+        (tester) async {
+      final controller = TextEditingController();
+      addTearDown(controller.dispose);
+      var changed = '';
+
+      await tester.pumpWidget(
+        buildApp(
+          NoneBorderCircularTextField(
+            editingController: controller,
+            hintText: '搜索',
+            needPadding: false,
+            onChanged: (value) => changed = value,
+          ),
+        ),
+      );
+
+      await tester.enterText(find.byType(TextField), '音乐');
+      expect(controller.text, '音乐');
+      expect(changed, '音乐');
+    });
+
+    testWidgets('SettingsAction renders value and forwards tap',
+        (tester) async {
+      var taps = 0;
+      await tester.pumpWidget(
+        buildApp(
+          SettingsAction(
+            title: '播放设置',
+            subtitle: '调整播放器行为',
+            value: '默认',
+            onTap: () => taps++,
+          ),
+        ),
+      );
+
+      expect(find.text('播放设置'), findsOneWidget);
+      expect(find.text('调整播放器行为'), findsOneWidget);
+      expect(find.text('默认'), findsOneWidget);
+      await tester.tap(find.text('播放设置'));
+      expect(taps, 1);
+    });
+
+    testWidgets('SettingsSwitch forwards the selected value', (tester) async {
+      bool? changed;
+      await tester.pumpWidget(
+        buildApp(
+          SettingsSwitch(
+            value: false,
+            title: '自动播放',
+            onChanged: (value) => changed = value,
+          ),
+        ),
+      );
+
+      await tester.tap(find.byType(Switch));
+      expect(changed, isTrue);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Restyle the main Flutter app with a YesPlayMusic-inspired visual system while keeping Slive branding and behavior.
- Add semantic design tokens/theme extension and refresh shared widgets, settings, discovery, sync, mine/follow/history, and live-room UI.
- Replace stale smoke tests with lightweight theme/widget/integration smoke coverage.

## Validation
- git diff --check
- Static review of changed scope and protected paths
- Could not run Flutter locally because dart/flutter/fvm are not available in this environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)